### PR TITLE
Add README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Brokenspoke-analyzer
 
+[![ci](https://github.com/PeopleForBikes/brokenspoke-analyzer/actions/workflows/ci.yaml/badge.svg)](https://github.com/PeopleForBikes/brokenspoke-analyzer/actions/workflows/ci.yaml)
+[![Latest Version](https://img.shields.io/github/v/tag/PeopleForBikes/brokenspoke-analyzer?sort=semver&label=version)](https://github.com/PeopleForBikes/brokenspoke-analyzer/)
+[![License](https://img.shields.io/badge/license-mit-blue.svg)](https://github.com/PeopleForBikes/brokenspoke-analyzer/blob/main/LICENSE)
+[![Code of Conduct](https://img.shields.io/badge/code_of_conduct-🌐-ff69b4.svg?logoColor=white)](https://github.com/PeopleForBikes/brokenspoke-analyzer/blob/main/code-of-conduct.md)
+
 The Brokenspoke Analyzer is a tool allowing the user to run “Bicycle Network
 Analysis” locally.
 


### PR DESCRIPTION
Adds some badges to the README.md file to provide some information
quickly and semi-visually, like the license or version number for
instance.

Fixes PeopleForBikes/brokenspoke-analyzer#28
