### PR TITLE
Prepare codebase for 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.0] - 2022-08-14
+
+First stable version.
+
+[1.0.0]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.0.0
+
 ## [1.0.0-rc.1] - 2022-08-07
 
 This is the first usable release. It is possible to run analysis for any city in

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,16 +13,17 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
-
+from importlib import metadata
 
 # -- Project information -----------------------------------------------------
 
 project = "Brokenspoke Analyzer"
 copyright = "2022, PeopleForBikes"
 author = "PeopleForBikes"
+package = "brokenspoke-analyzer"
 
 # The full version, including alpha/beta/rc tags
-release = "1.0.0-rc.1"
+release = metadata.version(package)
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "brokenspoke-analyzer"
-version = "0.1.0"
+version = "1.0.0"
 description = "Run a BNA analysis locally."
 authors = ["Rémy Greinhofer <remy.greinhofer@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Prepares the codebase for 1.0.0 release.

The documentation configuration was updated to automatically pick up the
version number from the package metadata itself, removing the need to
manually update it.
