### PR TITLE
Make output_dir an option for the prepare command

### DIFF
--- a/brokenspoke_analyzer/cli.py
+++ b/brokenspoke_analyzer/cli.py
@@ -17,7 +17,7 @@ from brokenspoke_analyzer.core import (
 from brokenspoke_analyzer.pyrosm.data import get_data
 
 # Default values
-OutputDir = typer.Argument(
+OutputDir = typer.Option(
     default="./data",
     exists=False,
     file_okay=False,


### PR DESCRIPTION
Converts `output_dir` from an optional argument to an option. This
allows the user to specify the output directory without having to
specify a state.

Fixes PeopleForBikes/brokenspoke-analyzer#190

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
