### PR TITLE
Fix CI release workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: startsWith(github.ref, 'refs/tags/')
     needs:
       - lint
       - test
@@ -74,12 +74,12 @@ jobs:
           publish_dir: docs/build/html/
 
   release:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
     needs:
       - lint
       - test
       - docs
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v3
       - name: Get Changelog Entry


### PR DESCRIPTION
Fixes the trigger condition to publish a new release.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
