### PR TITLE
Fix Geofabrik downloader for Spain

### DIFF
--- a/brokenspoke_analyzer/pyrosm/data/geofabrik.py
+++ b/brokenspoke_analyzer/pyrosm/data/geofabrik.py
@@ -29,7 +29,7 @@ netherlands_url = "europe/netherlands/"
 nordrhein_wesfalen_url = "europe/germany/nordrhein-westfalen/"
 poland_url = "europe/poland/"
 russia_url = "russia/"
-spain_url = "europe/spain"
+spain_url = "europe/spain/"
 usa_url = "north-america/us/"
 
 
@@ -881,6 +881,54 @@ class CentralAmerica:
         return self.available
 
 
+class Spain:
+    regions = [
+        "andalucía",
+        "aragón",
+        "asturias",
+        "cantabria",
+        "castilla-la mancha",
+        "castilla y león",
+        "cataluña",
+        "ceuta",
+        "extremadura",
+        "galicia",
+        "islas baleares",
+        "la rioja",
+        "madrid",
+        "melilla",
+        "murcia",
+        "navarra",
+        "país vasco",
+        "valencia",
+    ]
+
+    available = regions
+    available.sort()
+
+    country = {
+        "name": "spain" + suffix,
+        "url": URL + europe_url + "spain" + suffix,
+    }
+
+    # Create data sources
+    _sources = {
+        region: {
+            "name": region.replace("_", "-") + suffix,
+            "url": URL + spain_url + region.replace("_", "-") + suffix,
+        }
+        for region in regions
+    }
+
+    __dict__ = _sources
+
+    def __getattr__(self, name):
+        return self.__dict__[name]
+
+    def __call__(self):
+        return self.available
+
+
 class Europe:
     # Country specific subregions
     france = France()
@@ -890,6 +938,7 @@ class Europe:
     poland = Poland()
     germany = Germany()
     netherlands = Netherlands()
+    spain = Spain()
 
     regions = [
         "albania",
@@ -1174,54 +1223,6 @@ class SubRegions:
         self.usa = USA()
 
         self.available = {name: self.__dict__[name].available for name in self.regions}
-
-    def __getattr__(self, name):
-        return self.__dict__[name]
-
-    def __call__(self):
-        return self.available
-
-
-class Spain:
-    regions = [
-        "Andalucía",
-        "Aragón",
-        "Asturias",
-        "Cantabria",
-        "Castilla-La Mancha",
-        "Castilla y León",
-        "Cataluña",
-        "Ceuta",
-        "Extremadura",
-        "Galicia",
-        "Islas Baleares",
-        "La Rioja",
-        "Madrid",
-        "Melilla",
-        "Murcia",
-        "Navarra",
-        "País Vasco",
-        "Valencia",
-    ]
-
-    available = regions
-    available.sort()
-
-    country = {
-        "name": "spain" + suffix,
-        "url": URL + europe_url + "spain" + suffix,
-    }
-
-    # Create data sources
-    _sources = {
-        region: {
-            "name": region.replace("_", "-") + suffix,
-            "url": URL + spain_url + region.replace("_", "-") + suffix,
-        }
-        for region in regions
-    }
-
-    __dict__ = _sources
 
     def __getattr__(self, name):
         return self.__dict__[name]


### PR DESCRIPTION
Fixes the Geofabrik downloader for Spain.

There are 3 problems with the current implementation:

- a trailing slash ('/') is missing for the spanish URL
- Spain is not added as a European subregion
- the Spanish regions use mix-case but should be all lower case

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
