### PR TITLE
Fix the release workflow name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: ci
+name: release
 
 on:
   push:


### PR DESCRIPTION
Renames the release workflow to 'release'.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
