### PR TITLE
Bind population file into data directory

### DIFF
--- a/brokenspoke_analyzer/core/processhelper.py
+++ b/brokenspoke_analyzer/core/processhelper.py
@@ -66,6 +66,7 @@ def run_analysis(
             f"-e RUN_IMPORT_JOBS={run_import_jobs}",
             "-e PFB_DEBUG=1",
             f'-v "{output_dir}":{dest}',
+            f'-v "{output_dir}/population.zip":/data/population.zip',
             docker_image,
         ]
     )


### PR DESCRIPTION
The directory where the BNA looks for the population file is not bound
to the output dir, but hardcoded to the "/data" directory in the
container. Therefore the population faile **MUST** be mapped to the
directory.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
