### PR TITLE
Ensure UTF8 encoding

### DIFF
--- a/brokenspoke_analyzer/core/analysis.py
+++ b/brokenspoke_analyzer/core/analysis.py
@@ -138,7 +138,7 @@ def retrieve_city_boundaries(output, country, city, state=None):
 
     # Export the boundaries.
     slug = slugify(query)
-    city_gdf.to_file(output / f"{slug}.shp")
+    city_gdf.to_file(output / f"{slug}.shp", encoding="utf-8")
     city_gdf.to_file(output / f"{slug}.geojson")
 
     return slug


### PR DESCRIPTION
Ensures the boundary shapefiles are UTF8 encoded.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
