### PR TITLE
Sanitize Docker variables

### DIFF
--- a/brokenspoke_analyzer/core/analysis.py
+++ b/brokenspoke_analyzer/core/analysis.py
@@ -262,7 +262,7 @@ async def download_lodes_data(session, output_dir, state, part, year):
     More information about the formast can be found on the website:
     https://lehd.ces.census.gov/data/#lodes.
     """
-    lehd_url = f"http://lehd.ces.census.gov/data/lodes/LODES7/{state.lower()}/od/"
+    lehd_url = f"http://lehd.ces.census.gov/data/lodes/LODES7/{state.lower()}/od"
     lehd_filename = f"{state.lower()}_od_{part.lower()}_JT00_{year}.csv.gz"
     gzipped_lehd_file = output_dir / lehd_filename
     decompressed_lefh_file = output_dir / gzipped_lehd_file.stem
@@ -301,7 +301,7 @@ async def download_census_waterblocks(session, output_dir):
 
 async def download_2010_census_blocks(session, output_dir, fips):
     """Download a 2010 census tabulation block code for a specific state."""
-    tabblk2010_url = "http://www2.census.gov/geo/tiger/TIGER2010BLKPOPHU/"
+    tabblk2010_url = "http://www2.census.gov/geo/tiger/TIGER2010BLKPOPHU"
     tabblk2010_filename = f"tabblock2010_{fips}_pophu.zip"
     tabblk2010_file = output_dir / tabblk2010_filename
     population_file = output_dir / "population.shp"

--- a/brokenspoke_analyzer/core/processhelper.py
+++ b/brokenspoke_analyzer/core/processhelper.py
@@ -57,15 +57,15 @@ def run_analysis(
             "docker",
             "run",
             "--rm",
-            f'-e PFB_SHPFILE="{dest / city_shp.name}"',
-            f'-e PFB_OSM_FILE="{dest / pfb_osm_file}"',
-            f"-e PFB_COUNTRY={pfb_country}",
-            f"-e PFB_STATE={pfb_state}",
+            f'-e PFB_SHPFILE="{sanitize_values(str(dest / city_shp.name))}"',
+            f'-e PFB_OSM_FILE="{sanitize_values(str(dest / pfb_osm_file))}"',
+            f"-e PFB_COUNTRY={sanitize_values(str(pfb_country))}",
+            f"-e PFB_STATE={sanitize_values(str(pfb_state))}",
             f"-e PFB_STATE_FIPS={state_fips}",
-            f"-e NB_OUTPUT_DIR={dest}",
+            f'-e NB_OUTPUT_DIR="{sanitize_values(str(dest))}"',
             f"-e RUN_IMPORT_JOBS={run_import_jobs}",
             "-e PFB_DEBUG=1",
-            f'-v "{output_dir}":{dest}',
+            f'-v "{output_dir}":"{sanitize_values(str(dest))}"',
             f'-v "{output_dir}/population.zip":/data/population.zip',
             docker_image,
         ]
@@ -104,3 +104,20 @@ def run_osmosis(polygon_file_name, region_file_name, reduced_file_name):
         ]
     )
     run(osmosis_cmd)
+
+
+def sanitize_values(value: str) -> str:
+    """
+    Removes spaces and other invalid characters from the value.
+
+    Example:
+
+    >>> sanitize_values("a directory with spaces")
+    'a_directory_with_spaces'
+
+    >>> sanitize_values("")
+    None
+    """
+    if not value:
+        return None
+    return value.replace(" ", "_")


### PR DESCRIPTION
Docker variables cannot contain spaces, therefore we must replace them
with underscores (`_`).

Drive-by:
- Removes trailing spaces in URLs.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
