### PR TITLE
Add California dataset

### DIFF
--- a/brokenspoke_analyzer/pyrosm/data/geofabrik.py
+++ b/brokenspoke_analyzer/pyrosm/data/geofabrik.py
@@ -40,6 +40,7 @@ class USA:
         "alaska",
         "arizona",
         "arkansas",
+        "california",
         "colorado",
         "connecticut",
         "delaware",


### PR DESCRIPTION
The OSM dataset for the state of California was only available through
"Northern California" or "Southern California", but as these are not
official states the requests for any city in California were failing.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
