### PR TITLE
Ensure regions use only ASCII characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ and this project adheres to
 
 [#205]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/205
 [#206]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/206
-[1.2.1]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.2.1
+[1.2.1]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.2.1
 
 ## [1.2.0] - 2023-06-14
 
@@ -56,7 +57,8 @@ and this project adheres to
 [#152]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/152
 [#190]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/190
 [#191]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/191
-[1.2.0]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.2.0
+[1.2.0]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.2.0
 
 ## [1.1.0] - 2022-10-08
 
@@ -69,13 +71,15 @@ and this project adheres to
 - Updated the analyzer image to 0.16.1. [#52]
 
 [#52]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/52
-[1.1.0]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.1.0
+[1.1.0]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.1.0
 
 ## [1.0.0] - 2022-08-14
 
 First stable version.
 
-[1.0.0]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.0.0
+[1.0.0]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.0.0
 
 ## [1.0.0-rc.1] - 2022-08-07
 
@@ -85,4 +89,5 @@ the world (although the analyzer will fail for some of them).
 The tool is still a bit rough on the edges, that is why this is a release
 candidate, but the quirks will be ironned out for 1.0.0.
 
-[1.0.0-rc.1]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.0.0-rc.1
+[1.0.0-rc.1]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.0.0-rc.1

--- a/brokenspoke_analyzer/cli.py
+++ b/brokenspoke_analyzer/cli.py
@@ -15,7 +15,6 @@ from brokenspoke_analyzer.core import (
     analysis,
     processhelper,
 )
-from brokenspoke_analyzer.pyrosm.data import get_data
 
 # Default values
 OutputDir = typer.Option(
@@ -195,8 +194,8 @@ async def prepare_(
 
     # Download the OSM region file.
     with console.status("[bold green]Downloading the OSM region file..."):
-        dataset = state if state else country
-        region_file_path = get_data(dataset, directory=output_dir)
+        region = state if state else country
+        region_file_path = analysis.retrieve_region_file(region, output_dir)
         console.log("OSM Region file downloaded.")
 
     # Reduce the osm file with osmium.


### PR DESCRIPTION
The region files are downloaded from Geofabrik or BBike, and their names
are written using only ascii characters. Submitting a request to
download a region with a unicode character will result in a failure.
This patch ensures that the region names are submitted only with ASCII
characters.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
