### PR TITLE
Fix non-us city FIPS code

### DIFF
--- a/brokenspoke_analyzer/core/analysis.py
+++ b/brokenspoke_analyzer/core/analysis.py
@@ -215,7 +215,7 @@ def change_speed_limit(output, city, state_abbrev, speed):
     """Change the speed limit."""
     speedlimit_csv = output / "city_fips_speed.csv"
     speedlimit_csv.write_text(
-        f"city,state,fips_code_city,speed\n{city},{state_abbrev.lower()},1234567,{speed}\n"
+        f"city,state,fips_code_city,speed\n{city},{state_abbrev.lower()},{0:07},{speed}\n"
     )
 
 

--- a/docs/source/workflow.md
+++ b/docs/source/workflow.md
@@ -108,7 +108,7 @@ following format:
 
 ```text
 city,state,fips_code_city,speed
-valencia,al,1234567,50
+valencia,al,0000000,50
 ```
 
 This file must be named `city_fips_speed.csv` and stored in the `data`


### PR DESCRIPTION
Change the non-us city FIPS code from `1234567` to `0000000`.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
