### PR TITLE
Improve retrieve region logic

### DIFF
--- a/brokenspoke_analyzer/cli.py
+++ b/brokenspoke_analyzer/cli.py
@@ -194,8 +194,12 @@ async def prepare_(
 
     # Download the OSM region file.
     with console.status("[bold green]Downloading the OSM region file..."):
-        region = state if state else country
-        region_file_path = analysis.retrieve_region_file(region, output_dir)
+        try:
+            if not state:
+                raise ValueError
+            region_file_path = analysis.retrieve_region_file(state, output_dir)
+        except ValueError:
+            region_file_path = analysis.retrieve_region_file(country, output_dir)
         console.log("OSM Region file downloaded.")
 
     # Reduce the osm file with osmium.


### PR DESCRIPTION
When retrieving the region file, we now try first with the state, and if
it does not work, we then try with the country.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
