### PR TITLE
Add function to create SQLAlchemy psycopg engine

### DIFF
--- a/brokenspoke_analyzer/cli/configure.py
+++ b/brokenspoke_analyzer/cli/configure.py
@@ -1,8 +1,6 @@
 """Define the configure subcommand."""
 
 import typer
-from sqlalchemy import create_engine
-from sqlalchemy.engine import Engine
 
 from brokenspoke_analyzer.cli import common
 from brokenspoke_analyzer.core.database import dbcore
@@ -15,7 +13,7 @@ def docker(
     database_url: common.DatabaseURL,
 ) -> None:
     """Configures a database running in a docker container."""
-    engine = create_engine_(database_url)
+    engine = dbcore.create_psycopg_engine(database_url)
     dbcore.configure_docker_db(engine)
 
 
@@ -27,10 +25,5 @@ def custom(
     database_url: common.DatabaseURL,
 ) -> None:
     """Configures a database with custom values."""
-    engine = create_engine_(database_url)
+    engine = dbcore.create_psycopg_engine(database_url)
     dbcore.configure_db(engine, cores, memory_mb, pguser)
-
-
-def create_engine_(database_url: str) -> Engine:
-    """Create a SQLAlchemy engine."""
-    return create_engine(database_url.replace("postgresql://", "postgresql+psycopg://"))

--- a/brokenspoke_analyzer/cli/importer.py
+++ b/brokenspoke_analyzer/cli/importer.py
@@ -1,6 +1,5 @@
 import typer
 from loguru import logger
-from sqlalchemy import create_engine
 from typing_extensions import Annotated
 
 from brokenspoke_analyzer.cli import common
@@ -10,6 +9,7 @@ from brokenspoke_analyzer.core import (
     ingestor,
     utils,
 )
+from brokenspoke_analyzer.core.database import dbcore
 
 app = typer.Typer()
 
@@ -75,9 +75,7 @@ def neighborhood(
         raise ValueError("`state` is required for US cities")
 
     # Prepare the database connection.
-    engine = create_engine(
-        database_url.replace("postgresql://", "postgresql+psycopg://")
-    )
+    engine = dbcore.create_psycopg_engine(database_url)
 
     # Prepare the files to import.
     _, slug = analysis.osmnx_query(country, city, state)
@@ -119,9 +117,7 @@ def jobs(
         raise ValueError("a state abbreviation must be 2 letter long")
 
     # Prepare the database connection.
-    engine = create_engine(
-        database_url.replace("postgresql://", "postgresql+psycopg://")
-    )
+    engine = dbcore.create_psycopg_engine(database_url)
 
     # Import the jobs.
     ingestor.import_jobs(engine, state_abbreviation, census_year, input_dir)
@@ -142,9 +138,7 @@ def osm(
         raise ValueError("`fips_code` must be set")
 
     # Prepare the database connection.
-    engine = create_engine(
-        database_url.replace("postgresql://", "postgresql+psycopg://")
-    )
+    engine = dbcore.create_psycopg_engine(database_url)
 
     # Prepare the files to import.
     _, slug = analysis.osmnx_query(country, city, state)

--- a/brokenspoke_analyzer/cli/root.py
+++ b/brokenspoke_analyzer/cli/root.py
@@ -7,7 +7,6 @@ from importlib import resources
 import typer
 from loguru import logger
 from rich.console import Console
-from sqlalchemy import create_engine
 
 from brokenspoke_analyzer.cli import (
     common,
@@ -24,6 +23,7 @@ from brokenspoke_analyzer.core import (
     ingestor,
     utils,
 )
+from brokenspoke_analyzer.core.database import dbcore
 
 
 def callback(verbose: int = typer.Option(0, "--verbose", "-v", count=True)) -> None:
@@ -82,9 +82,7 @@ def compute_cmd(
         raise ValueError("`buffer` must be set")
 
     # Prepare the database connection.
-    engine = create_engine(
-        database_url.replace("postgresql://", "postgresql+psycopg://")
-    )
+    engine = dbcore.create_psycopg_engine(database_url)
 
     # Prepare directories.
     _, slug = analysis.osmnx_query(country, city, state)

--- a/brokenspoke_analyzer/cli/run_with.py
+++ b/brokenspoke_analyzer/cli/run_with.py
@@ -6,7 +6,6 @@ from importlib import resources
 import typer
 from loguru import logger
 from rich.console import Console
-from sqlalchemy import create_engine
 
 from brokenspoke_analyzer.cli import (
     common,
@@ -23,6 +22,7 @@ from brokenspoke_analyzer.core import (
     runner,
     utils,
 )
+from brokenspoke_analyzer.core.database import dbcore
 
 app = typer.Typer()
 
@@ -131,9 +131,7 @@ def run_(
         raise ValueError("`output_dir` must be set")
 
     # Prepare the database connection.
-    engine = create_engine(
-        database_url.replace("postgresql://", "postgresql+psycopg://")
-    )
+    engine = dbcore.create_psycopg_engine(database_url)
 
     # Prepare.
     logger.info("Prepare")

--- a/brokenspoke_analyzer/core/compute.py
+++ b/brokenspoke_analyzer/core/compute.py
@@ -7,7 +7,6 @@ import pathlib
 import typing
 
 from loguru import logger
-from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 
 from brokenspoke_analyzer.cli import common
@@ -477,9 +476,7 @@ def all(
         raise ValueError("`buffer` must be set")
 
     # Prepare the database connection.
-    engine = create_engine(
-        database_url.replace("postgresql://", "postgresql+psycopg://")
-    )
+    engine = dbcore.create_psycopg_engine(database_url)
 
     # Compute features.
     logger.info("Compute features")

--- a/brokenspoke_analyzer/core/database/dbcore.py
+++ b/brokenspoke_analyzer/core/database/dbcore.py
@@ -1,7 +1,10 @@
 """Define functions used to manipulate database data."""
 import pathlib
 
-from sqlalchemy import text
+from sqlalchemy import (
+    create_engine,
+    text,
+)
 from sqlalchemy.engine import Engine
 
 from brokenspoke_analyzer.core import runner
@@ -134,3 +137,8 @@ def configure_docker_db(engine: Engine) -> None:
     if not pguser:
         raise ValueError("postgresql user must be specified in the databse engine URL")
     configure_db(engine, docker_cores, docker_memory_mb, pguser)
+
+
+def create_psycopg_engine(database_url: str) -> Engine:
+    """Create a SQLAlchemy engine with the psycopg3 driver."""
+    return create_engine(database_url.replace("postgresql://", "postgresql+psycopg://"))

--- a/brokenspoke_analyzer/core/exporter.py
+++ b/brokenspoke_analyzer/core/exporter.py
@@ -2,7 +2,6 @@ import pathlib
 import typing
 from datetime import date
 
-from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 
 from brokenspoke_analyzer.core import runner
@@ -73,9 +72,7 @@ def auto_export(
 ) -> None:
     """Export PostgreSQL/PostGIS tables to their repective files."""
     # Prepare the database connection.
-    engine = create_engine(
-        database_url.replace("postgresql://", "postgresql+psycopg://")
-    )
+    engine = dbcore.create_psycopg_engine(database_url)
 
     # Export the tables per target.
     export_to_shp(export_dir, tables.get("shp", []), database_url)

--- a/integration/e2e.py
+++ b/integration/e2e.py
@@ -12,21 +12,18 @@ import os
 import pathlib
 
 from loguru import logger
-from sqlalchemy import create_engine
 
 from brokenspoke_analyzer.core import (
     compute,
     ingestor,
     runner,
 )
-from brokenspoke_analyzer.database import dbcore
+from brokenspoke_analyzer.core.database import dbcore
 
 
 def test_import_neighborhood():
     database_url = "postgresql://postgres:postgres@localhost:5432/postgres"
-    engine = create_engine(
-        database_url.replace("postgresql://", "postgresql+psycopg://")
-    )
+    engine = dbcore.create_psycopg_engine(database_url)
 
     os.environ["DATABASE_URL"] = database_url
 
@@ -55,9 +52,7 @@ def test_import_neighborhood():
 
 def test_retrieve_population():
     database_url = "postgresql://postgres:postgres@localhost:5432/postgres"
-    engine = create_engine(
-        database_url.replace("postgresql://", "postgresql+psycopg://")
-    )
+    engine = dbcore.create_psycopg_engine(database_url)
     population = ingestor.retrieve_population(engine)
     print(f"{population=}")
     assert population == 3199
@@ -66,18 +61,14 @@ def test_retrieve_population():
 def test_import_jobs():
     database_url = "postgresql://postgres:postgres@localhost:5432/postgres"
     os.environ["DATABASE_URL"] = database_url
-    engine = create_engine(
-        database_url.replace("postgresql://", "postgresql+psycopg://")
-    )
+    engine = dbcore.create_psycopg_engine(database_url)
     input_dir = pathlib.Path("data")
     ingestor.import_jobs(engine, "nm", 2019, input_dir)
 
 
 def test_import_all():
     database_url = "postgresql://postgres:postgres@localhost:5432/postgres"
-    engine = create_engine(
-        database_url.replace("postgresql://", "postgresql+psycopg://")
-    )
+    engine = dbcore.create_psycopg_engine(database_url)
 
     os.environ["DATABASE_URL"] = database_url
     os.environ["PGPASSWORD"] = "postgres"
@@ -129,9 +120,7 @@ def test_import_all():
 
 def test_retrieve_boundary_box():
     database_url = "postgresql://postgres:postgres@localhost:5432/postgres"
-    engine = create_engine(
-        database_url.replace("postgresql://", "postgresql+psycopg://")
-    )
+    engine = dbcore.create_psycopg_engine(database_url)
 
     bbox = ingestor.retrieve_boundary_box(engine)
     print(f"{bbox}")
@@ -141,9 +130,7 @@ def test_retrieve_boundary_box():
 def test_import_osm_data():
     """Require import neighborhood."""
     database_url = "postgresql://postgres:postgres@localhost:5432/postgres"
-    engine = create_engine(
-        database_url.replace("postgresql://", "postgresql+psycopg://")
-    )
+    engine = dbcore.create_psycopg_engine(database_url)
 
     os.environ["DATABASE_URL"] = database_url
 
@@ -174,9 +161,7 @@ def test_docker_info():
 
 def test_all():
     database_url = "postgresql://postgres:postgres@localhost:5432/postgres"
-    engine = create_engine(
-        database_url.replace("postgresql://", "postgresql+psycopg://")
-    )
+    engine = dbcore.create_psycopg_engine(database_url)
 
     os.environ["DATABASE_URL"] = database_url
     os.environ["PGPASSWORD"] = "postgres"


### PR DESCRIPTION
Instead of recreating the SQLAlchemy engine from the database URL and
overriding the driver manually, this patch implements a function which
does that for us.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
