### PR TITLE
Add e2e tests comparing results

### DIFF
--- a/brokenspoke_analyzer/cli/prepare.py
+++ b/brokenspoke_analyzer/cli/prepare.py
@@ -5,6 +5,7 @@ import typing
 import aiohttp
 import geopandas as gpd
 import typer
+from loguru import logger
 from rich.console import Console
 from tenacity import (
     Retrying,
@@ -57,6 +58,7 @@ def all(
         if not state and fips_code == "0":
             raise ValueError("`state` and `fips_code` are required for US cities")
 
+    logger.debug(f"{output_dir=}")
     asyncio.run(
         prepare_(
             country,
@@ -119,7 +121,11 @@ async def prepare_(
     # Reduce the osm file with osmium.
     with console.status(f"[bold green]Reducing the OSM file for {city} with osmium..."):
         polygon_file = output_dir / f"{slug}.geojson"
-        pfb_osm_file = output_dir / f"{slug}.osm"
+        pfb_osm_file = pathlib.Path(f"{slug}.osm")
+        logger.debug(f"{output_dir=}")
+        logger.debug(f"{region_file_path=}")
+        logger.debug(f"{polygon_file=}")
+        logger.debug(f"{pfb_osm_file=}")
         analysis.prepare_city_file(
             output_dir, region_file_path, polygon_file, pfb_osm_file
         )

--- a/brokenspoke_analyzer/core/runner.py
+++ b/brokenspoke_analyzer/core/runner.py
@@ -62,9 +62,9 @@ def run_analysis(
             "-e",
             "PFB_DEBUG=1",
             "-v",
-            f'"{output_dir}":"{dest}"',
+            f'"{output_dir.resolve(strict=True)}":"{dest}"',
             "-v",
-            f'"{output_dir}/population.zip":"/data/population.zip"',
+            f'"{output_dir.resolve(strict=True)}/population.zip":"/data/population.zip"',
             docker_image,
         ]
     )

--- a/integration/e2e_compare.py
+++ b/integration/e2e_compare.py
@@ -1,0 +1,185 @@
+"""Compare the overall scores between the original BNA and the modular BNA."""
+import os
+import pathlib
+
+import pytest
+from dotenv import load_dotenv
+from loguru import logger
+
+from brokenspoke_analyzer.cli import (
+    common,
+    run_with,
+)
+
+DELTA = 10
+
+
+@pytest.mark.parametrize(
+    "city,state,country,city_fips",
+    [
+        pytest.param(
+            "provincetown",
+            "massachusetts",
+            "usa",
+            "555535",
+            id="provincetown-ma-usa",
+            marks=[pytest.mark.xs, pytest.mark.usa, pytest.mark.main],
+        ),
+        pytest.param(
+            "santa rosa",
+            "new mexico",
+            "usa",
+            "3570670",
+            id="santa-rosa-nm-usa",
+            marks=[pytest.mark.xs, pytest.mark.usa, pytest.mark.main],
+        ),
+        pytest.param(
+            "crested butte",
+            "colorado",
+            "usa",
+            "818310",
+            id="crested-butte-co-usa",
+            marks=[pytest.mark.xs, pytest.mark.usa, pytest.mark.main],
+        ),
+        pytest.param(
+            "ancienne-lorette",
+            "québec",
+            "canada",
+            "0",
+            id="ancienne-lorette-quebec-canada",
+            marks=[pytest.mark.xs, pytest.mark.canada, pytest.mark.main],
+        ),
+        pytest.param(
+            "st. louis park",
+            "minnesota",
+            "usa",
+            "2757220",
+            id="st-louis-park-mn-usa",
+            marks=[pytest.mark.m, pytest.mark.usa],
+        ),
+        pytest.param(
+            "arcata",
+            "california",
+            "usa",
+            "602476",
+            id="arcata-ca-usa",
+            marks=[pytest.mark.m, pytest.mark.usa, pytest.mark.main],
+        ),
+        pytest.param(
+            "rehoboth beach",
+            "delaware",
+            "usa",
+            "1060290",
+            id="rehoboth-beach-de-usa",
+            marks=[pytest.mark.xs, pytest.mark.usa, pytest.mark.main],
+        ),
+        pytest.param(
+            "orange",
+            "new south wales",
+            "australia",
+            "0",
+            id="orange-nsw-australia",
+            marks=[pytest.mark.xs, pytest.mark.australia, pytest.mark.main],
+        ),
+        pytest.param(
+            "cañon city",
+            "colorado",
+            "usa",
+            "0811810",
+            id="canon-city-co-usa",
+            marks=[pytest.mark.s, pytest.mark.usa, pytest.mark.main],
+        ),
+        pytest.param(
+            "valencia",
+            "valencia",
+            "spain",
+            "0",
+            id="valencia-valencia-spain",
+            marks=[pytest.mark.xl, pytest.mark.spain, pytest.mark.europe],
+        ),
+        pytest.param(
+            "chambéry",
+            "savoie",
+            "france",
+            "0",
+            id="chambery-savoie-france",
+            marks=[pytest.mark.s, pytest.mark.france, pytest.mark.main],
+        ),
+        pytest.param(
+            "flagstaff",
+            "arizona",
+            "usa",
+            "0423620",
+            id="flagstaff-az-usa",
+            marks=[
+                pytest.mark.m,
+                pytest.mark.usa,
+            ],
+        ),
+        pytest.param(
+            "washington",
+            "district of columbia",
+            "usa",
+            "1150000",
+            id="washington-dc-usa",
+            marks=[
+                pytest.mark.xxl,
+                pytest.mark.usa,
+                pytest.mark.skip(reason="takes about a day to complete"),
+            ],
+        ),
+        pytest.param(
+            "jackson",
+            "wyoming",
+            "usa",
+            "5640120",
+            id="jackson-wy-usa",
+            marks=[pytest.mark.xs, pytest.mark.usa, pytest.mark.main],
+        ),
+        pytest.param(
+            "port townsend",
+            "washington",
+            "usa",
+            "5355855",
+            id="port-townsend-wa-usa",
+            marks=[
+                pytest.mark.s,
+                pytest.mark.usa,
+                pytest.mark.main,
+            ],
+        ),
+        pytest.param(
+            "alvarado",
+            "texas",
+            "usa",
+            "4802260",
+            id="alvarado-tx-usa",
+            marks=[pytest.mark.s, pytest.mark.usa, pytest.mark.main],
+        ),
+    ],
+)
+def test_compare(city: str, state: str, country: str, city_fips: str):
+    # Set the logging level.
+    logger.level("DEBUG")
+
+    # Load the environment variables.
+    load_dotenv()
+
+    # Run the comparison.
+    database_url = os.environ["DATABASE_URL"]
+    df = run_with.compare(
+        database_url=database_url,
+        country=country,
+        output_dir=pathlib.Path("data"),
+        speed_limit=common.DEFAULT_CITY_SPEED_LIMIT,
+        block_size=common.DEFAULT_BLOCKSIZE,
+        block_population=common.DEFAULT_BLOCK_POPULATION,
+        city=city,
+        state=state,
+        fips_code=city_fips,
+        census_year=common.DEFAULT_CENSUS_YEAR,
+        retries=common.DEFAULT_RETRIES,
+    )
+
+    # Assert the deltas are within range.
+    assert all(df.delta.apply(lambda x: -DELTA <= x <= DELTA))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,21 @@ omit = [
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-p no:warnings --cov-report term-missing --cov-report html --xdoctest"
+markers = [
+  "australia",
+  "canada",
+  "europe",
+  "france",
+  "spain",
+  "usa",
+  "main: main test suite",
+  "xs: runs under 5min",
+  "s: runs under 15min",
+  "m: runs under 60min (1h)",
+  "l: runs under 180min (2h)",
+  "xl: runs under 360min (6h)",
+  "xxl: runs under 720min (12h / 1/2day)",
+]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Adds tests comparing the results between the brokenspokespoke analyzer
and the original BNA.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
