### PR TITLE
Add download validation

### DIFF
--- a/brokenspoke_analyzer/cli/prepare.py
+++ b/brokenspoke_analyzer/cli/prepare.py
@@ -20,6 +20,7 @@ from brokenspoke_analyzer.core import (
     constant,
     downloader,
     runner,
+    utils,
 )
 
 app = typer.Typer()
@@ -123,6 +124,9 @@ async def prepare_(
             region_file_path = retryer(
                 analysis.retrieve_region_file, country, output_dir
             )
+        region_file_path_md5 = pathlib.Path(str(region_file_path) + ".md5")
+        if not utils.file_checksum_ok(region_file_path, region_file_path_md5):
+            raise ValueError("Invalid OSM region file")
         console.log("OSM Region file downloaded.")
 
     # Reduce the osm file with osmium.

--- a/brokenspoke_analyzer/pyrosm/data/__init__.py
+++ b/brokenspoke_analyzer/pyrosm/data/__init__.py
@@ -123,8 +123,17 @@ available = {
 
 
 def retrieve(data, update, directory):
+    download(
+        url=data["url"] + ".md5",
+        filename=data["name"] + ".md5",
+        update=update,
+        target_dir=directory,
+    )
     return download(
-        url=data["url"], filename=data["name"], update=update, target_dir=directory
+        url=data["url"],
+        filename=data["name"],
+        update=update,
+        target_dir=directory,
     )
 
 


### PR DESCRIPTION
Adds feature to validate downloaded pbf osm files using md5 checksums.
Adds feature to `gunzip` to check if downlaoded `gz` file is valid.

Fixes PeopleForBikes/brokenspoke-analyzer/issues/238
