### PR TITLE
Rename "census-year" CLI flag

### DIFF
--- a/brokenspoke_analyzer/cli/common.py
+++ b/brokenspoke_analyzer/cli/common.py
@@ -8,7 +8,7 @@ from typing_extensions import Annotated
 DEFAULT_BLOCK_POPULATION = 100
 DEFAULT_BLOCK_SIZE = 500
 DEFAULT_BUFFER = 2680
-DEFAULT_CENSUS_YEAR = 2019
+DEFAULT_LODES_YEAR = 2019
 DEFAULT_CITY_FIPS_CODE = "0"  # "0" means an non-US city.
 DEFAULT_CITY_SPEED_LIMIT = 30
 DEFAULT_CONTAINER_NAME = "brokenspoke-analyzer"
@@ -28,8 +28,8 @@ BlockSize = Annotated[
     typer.Option(help="size of a synthetic block for non-US cities (in meters)"),
 ]
 Buffer = Annotated[typing.Optional[int], typer.Option(help="define the buffer area")]
-CensusYear = Annotated[
-    typing.Optional[int], typer.Option(help="year to use to retrieve US census data")
+LODESYear = Annotated[
+    typing.Optional[int], typer.Option(help="year to use to retrieve US job data")
 ]
 City = Annotated[str, typer.Argument()]
 ContainerName = Annotated[

--- a/brokenspoke_analyzer/cli/importer.py
+++ b/brokenspoke_analyzer/cli/importer.py
@@ -22,7 +22,7 @@ def all(
     city: common.City,
     region: common.Region = None,
     fips_code: common.FIPSCode = common.DEFAULT_CITY_FIPS_CODE,
-    census_year: common.CensusYear = common.DEFAULT_CENSUS_YEAR,
+    lodes_year: common.LODESYear = common.DEFAULT_LODES_YEAR,
     buffer: common.Buffer = common.DEFAULT_BUFFER,
 ) -> None:
     """Import all files into database."""
@@ -41,7 +41,7 @@ def all(
         jobs(
             input_dir=input_dir,
             state_abbreviation=state_abbrev,
-            census_year=census_year,
+            lodes_year=lodes_year,
             database_url=database_url,
         )
     osm(
@@ -104,12 +104,12 @@ def jobs(
     database_url: common.DatabaseURL,
     input_dir: common.InputDir,
     state_abbreviation: Annotated[str, typer.Argument(help="two-letter US state name")],
-    census_year: common.CensusYear = common.DEFAULT_CENSUS_YEAR,
+    lodes_year: common.LODESYear = common.DEFAULT_LODES_YEAR,
 ) -> None:
     """Import US census job data."""
     # Make mypy happy.
-    if not census_year:
-        raise ValueError("`census_year` must be set")
+    if not lodes_year:
+        raise ValueError("`lodes_year` must be set")
 
     # validate the US state.
     state_abbreviation = state_abbreviation.lower()
@@ -120,7 +120,7 @@ def jobs(
     engine = dbcore.create_psycopg_engine(database_url)
 
     # Import the jobs.
-    ingestor.import_jobs(engine, state_abbreviation, census_year, input_dir)
+    ingestor.import_jobs(engine, state_abbreviation, lodes_year, input_dir)
 
 
 @app.command()

--- a/brokenspoke_analyzer/cli/prepare.py
+++ b/brokenspoke_analyzer/cli/prepare.py
@@ -37,7 +37,7 @@ def all(
     block_size: common.BlockSize = common.DEFAULT_BLOCK_SIZE,
     block_population: common.BlockPopulation = common.DEFAULT_BLOCK_POPULATION,
     retries: common.Retries = common.DEFAULT_RETRIES,
-    census_year: common.CensusYear = common.DEFAULT_CENSUS_YEAR,
+    lodes_year: common.LODESYear = common.DEFAULT_LODES_YEAR,
 ) -> None:
     """Prepare all the files required for an analysis."""
     # Make MyPy happy.
@@ -51,8 +51,8 @@ def all(
         raise ValueError("`block_population` must be set")
     if not retries:
         raise ValueError("`retries` must be set")
-    if not census_year:
-        raise ValueError("`census_year` must be set")
+    if not lodes_year:
+        raise ValueError("`lodes_year` must be set")
 
     # Ensure US/USA cities have the right parameters.
     if country.upper() == "US":
@@ -72,7 +72,7 @@ def all(
             block_size=block_size,
             block_population=block_population,
             retries=retries,
-            census_year=census_year,
+            lodes_year=lodes_year,
         )
     )
 
@@ -85,7 +85,7 @@ async def prepare_(
     block_size: int,
     block_population: int,
     retries: int,
-    census_year: int,
+    lodes_year: int,
     region: typing.Optional[str] = None,
 ) -> None:
     """Prepare and kicks off the analysis."""
@@ -169,7 +169,7 @@ async def prepare_(
             )
     else:
         async with aiohttp.ClientSession() as session:
-            lodes_year = census_year
+            lodes_year = lodes_year
             with console.status(
                 f"[bold green]Fetching {lodes_year} US employment data..."
             ):

--- a/brokenspoke_analyzer/cli/root.py
+++ b/brokenspoke_analyzer/cli/root.py
@@ -128,7 +128,7 @@ def run(
     city_speed_limit: common.SpeedLimit = common.DEFAULT_CITY_SPEED_LIMIT,
     block_size: common.BlockSize = common.DEFAULT_BLOCK_SIZE,
     block_population: common.BlockPopulation = common.DEFAULT_BLOCK_POPULATION,
-    census_year: common.CensusYear = common.DEFAULT_CENSUS_YEAR,
+    lodes_year: common.LODESYear = common.DEFAULT_LODES_YEAR,
     retries: common.Retries = common.DEFAULT_RETRIES,
     max_trip_distance: common.MaxTripDistance = common.DEFAULT_MAX_TRIP_DISTANCE,
 ) -> None:
@@ -144,7 +144,7 @@ def run(
         city_speed_limit=city_speed_limit,
         block_size=block_size,
         block_population=block_population,
-        census_year=census_year,
+        lodes_year=lodes_year,
         retries=retries,
         max_trip_distance=max_trip_distance,
     )

--- a/brokenspoke_analyzer/cli/run_with.py
+++ b/brokenspoke_analyzer/cli/run_with.py
@@ -40,7 +40,7 @@ def compose(
     city_speed_limit: common.SpeedLimit = common.DEFAULT_CITY_SPEED_LIMIT,
     block_size: common.BlockSize = common.DEFAULT_BLOCK_SIZE,
     block_population: common.BlockPopulation = common.DEFAULT_BLOCK_POPULATION,
-    census_year: common.CensusYear = common.DEFAULT_CENSUS_YEAR,
+    lodes_year: common.LODESYear = common.DEFAULT_LODES_YEAR,
     retries: common.Retries = common.DEFAULT_RETRIES,
     max_trip_distance: common.MaxTripDistance = common.DEFAULT_MAX_TRIP_DISTANCE,
 ) -> pathlib.Path:
@@ -66,7 +66,7 @@ def compose(
             city_speed_limit=city_speed_limit,
             block_size=block_size,
             block_population=block_population,
-            census_year=census_year,
+            lodes_year=lodes_year,
             retries=retries,
             max_trip_distance=max_trip_distance,
         )
@@ -137,7 +137,7 @@ def compare(
     city_speed_limit: common.SpeedLimit = common.DEFAULT_CITY_SPEED_LIMIT,
     block_size: common.BlockSize = common.DEFAULT_BLOCK_SIZE,
     block_population: common.BlockPopulation = common.DEFAULT_BLOCK_POPULATION,
-    census_year: common.CensusYear = common.DEFAULT_CENSUS_YEAR,
+    lodes_year: common.LODESYear = common.DEFAULT_LODES_YEAR,
     retries: common.Retries = common.DEFAULT_RETRIES,
     max_trip_distance: common.MaxTripDistance = common.DEFAULT_MAX_TRIP_DISTANCE,
 ) -> pd.DataFrame:
@@ -156,7 +156,7 @@ def compare(
         city_speed_limit=city_speed_limit,
         block_size=block_size,
         block_population=block_population,
-        census_year=census_year,
+        lodes_year=lodes_year,
         retries=retries,
         max_trip_distance=max_trip_distance,
     )
@@ -195,7 +195,7 @@ def run_(
     city_speed_limit: typing.Optional[int] = common.DEFAULT_CITY_SPEED_LIMIT,
     block_size: typing.Optional[int] = common.DEFAULT_BLOCK_SIZE,
     block_population: typing.Optional[int] = common.DEFAULT_BLOCK_POPULATION,
-    census_year: common.CensusYear = common.DEFAULT_CENSUS_YEAR,
+    lodes_year: typing.Optional[int] = common.DEFAULT_LODES_YEAR,
     retries: typing.Optional[int] = common.DEFAULT_RETRIES,
     max_trip_distance: typing.Optional[int] = common.DEFAULT_MAX_TRIP_DISTANCE,
 ) -> pathlib.Path:
@@ -245,7 +245,7 @@ def run_(
         country=country,
         city=city,
         region=region,
-        census_year=census_year,
+        lodes_year=lodes_year,
         buffer=buffer,
         fips_code=fips_code,
     )

--- a/brokenspoke_analyzer/core/ingestor.py
+++ b/brokenspoke_analyzer/core/ingestor.py
@@ -246,7 +246,7 @@ def retrieve_boundary_box(engine: Engine) -> tuple[float, float, float, float]:
 
 
 def import_jobs(
-    engine: Engine, state: str, census_year: int, input_dir: pathlib.Path
+    engine: Engine, state: str, lodes_year: int, input_dir: pathlib.Path
 ) -> None:
     """
     Import all jobs from US census data.
@@ -255,7 +255,7 @@ def import_jobs(
     """
     state = state.lower()
     for part in LODESPart:
-        csvfile = input_dir / f"{state}_od_{part.value}_JT00_{census_year}.csv"
+        csvfile = input_dir / f"{state}_od_{part.value}_JT00_{lodes_year}.csv"
         csvfile = csvfile.resolve(strict=True)
         logger.debug(f"Importing job file: {csvfile}")
         if not csvfile.exists():
@@ -480,7 +480,7 @@ def import_all(
     city_speed_limits_csv: pathlib.Path,
     city_fips: str,
     state: typing.Optional[str] = None,
-    census_year: typing.Optional[int] = None,
+    lodes_year: typing.Optional[int] = None,
     city_speed_limit_override: typing.Optional[str] = None,
 ) -> None:
     """Import all the data."""
@@ -496,9 +496,9 @@ def import_all(
     state_abbrev, state_fips, run_import_jobs = analysis.derive_state_info(state)
     logger.debug(f"{run_import_jobs=}")
     if run_import_jobs == "1":
-        if not census_year:
-            raise ValueError("'census_year' is required when importing job data")
-        import_jobs(engine, state_abbrev, census_year, input_dir)
+        if not lodes_year:
+            raise ValueError("'lodes_year' is required when importing job data")
+        import_jobs(engine, state_abbrev, lodes_year, input_dir)
     import_osm_data(
         engine,
         osm_file,

--- a/integration/e2e.py
+++ b/integration/e2e.py
@@ -86,7 +86,7 @@ def test_import_all():
     city_fips = "3570670"
     buffer = 2680
     output_srid = 32613
-    census_year = 2019
+    lodes_year = 2019
     # state_fips = "35"
     input_dir = pathlib.Path("data")
     boundary_file = input_dir / "santa-rosa-new-mexico-usa.shp"
@@ -117,7 +117,7 @@ def test_import_all():
         city_speed_limits_csv,
         city_fips,
         state,
-        census_year,
+        lodes_year,
     )
 
 
@@ -179,7 +179,7 @@ def test_all():
     city_fips = "3570670"
     buffer = 2680
     output_srid = 32613
-    census_year = 2019
+    lodes_year = 2019
     # state_fips = "35"
     input_dir = pathlib.Path("data")
     boundary_file = input_dir / "santa-rosa-new-mexico-usa.shp"
@@ -219,7 +219,7 @@ def test_all():
         city_speed_limits_csv,
         city_fips,
         state,
-        census_year,
+        lodes_year,
     )
 
     compute.all(

--- a/integration/e2e_compare.py
+++ b/integration/e2e_compare.py
@@ -174,7 +174,7 @@ def test_compare(city: str, state: str, country: str, city_fips: str):
         city=city,
         region=state,
         fips_code=city_fips,
-        census_year=common.DEFAULT_CENSUS_YEAR,
+        lodes_year=common.DEFAULT_LODES_YEAR,
         retries=common.DEFAULT_RETRIES,
     )
 


### PR DESCRIPTION
Renames the `census-year` flag into `lodes-year` to avoid the confusion
with the census tract year.

Fixes PeopleForBikes/brokenspoke-analyzer#332

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
