### PR TITLE
Make pgAdmin optional

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -4,7 +4,7 @@ services:
     image: bna:mechanics
     shm_size: 1g
     build:
-      dockerfile: ./compose//Dockerfile
+      dockerfile: ghcr.io/rgreinho/docker-postgis-bna:13-3.1
     environment:
         POSTGRES_PASSWORD: postgres
         POSTGRES_USER: postgres
@@ -15,17 +15,6 @@ services:
       - 5432:5432
     volumes:
         - postgres:/var/lib/postgresql/data
-
-  pgadmin:
-    image: dpage/pgadmin4:7.6
-    environment:
-        PGADMIN_DEFAULT_EMAIL: admin@pgadmin.com
-        PGADMIN_DEFAULT_PASSWORD: admin
-        PGADMIN_LISTEN_PORT: 80
-    ports:
-      - 8484:80
-    volumes:
-        - ./compose/compose-config/servers.json:/pgadmin4/servers.json
 
 volumes:
   postgres:

--- a/compose/pgAdmin/compose-pgadmin.yml
+++ b/compose/pgAdmin/compose-pgadmin.yml
@@ -1,0 +1,16 @@
+version: "3"
+include:
+  - ../../compose.yml
+
+services:
+  pgadmin:
+    image: dpage/pgadmin4:7.6
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@pgadmin.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+      PGADMIN_LISTEN_PORT: 80
+    ports:
+      - 8484:80
+    volumes:
+      - ./config/servers.json:/pgadmin4/servers.json
+      - ./config/pgpass:/pgadmin4/pgpass

--- a/compose/pgAdmin/config/pgpass
+++ b/compose/pgAdmin/config/pgpass
@@ -1,0 +1,2 @@
+#hostname:port:database:username:password
+postgres:5432:*:postgres:postgres

--- a/compose/pgAdmin/config/servers.json
+++ b/compose/pgAdmin/config/servers.json
@@ -1,11 +1,12 @@
 {
   "Servers": {
     "1": {
-      "Name": "bna",
-      "Group": "bna",
+      "Name": "BNA",
+      "Group": "PeopleForBikes",
       "Username": "postgres",
       "Host": "postgres",
       "Port": 5432,
+      "PassFile": "/pgpass",
       "SSLMode": "prefer",
       "MaintenanceDB": "postgres"
     }


### PR DESCRIPTION
Ensures the main Docker Compose file start only the required
PostgreSQL/PostGIS server, while keeping the ability to plug other
components like pgAdmin.

Fixes PeopleForBikes/brokenspoke-analyzer#300

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
