### PR TITLE
Add parameter to specify the S3 bucket name

### DIFF
--- a/brokenspoke_analyzer/cli/root.py
+++ b/brokenspoke_analyzer/cli/root.py
@@ -171,6 +171,9 @@ def run(
     retries: common.Retries = common.DEFAULT_RETRIES,
     max_trip_distance: common.MaxTripDistance = common.DEFAULT_MAX_TRIP_DISTANCE,
     with_export: typing.Optional[exporter.Exporter] = exporter.Exporter.local,
+    s3_bucket: Annotated[
+        typing.Optional[str], typer.Option(help="S3 bucket name where to export")
+    ] = None,
 ) -> None:
     """Run an analysis."""
     run_with.run_(
@@ -188,4 +191,5 @@ def run(
         retries=retries,
         max_trip_distance=max_trip_distance,
         with_export=with_export,
+        s3_bucket=s3_bucket,
     )

--- a/brokenspoke_analyzer/core/exporter.py
+++ b/brokenspoke_analyzer/core/exporter.py
@@ -41,8 +41,6 @@ TABLE_CATALOG = {
     ],
 }
 
-BNA_RESULT_BUCKET = "remy-is-testing"
-
 
 class Exporter(str, Enum):
     none = "none"


### PR DESCRIPTION
Instead of using a default hardcoded bucket name, this patch wires the
logic to use the bucket name provided via the CLI.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
