### PR TITLE
Update deployment workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,40 +7,12 @@ on:
       - synchronize
       - reopened
 
-jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v1
-      - uses: ts-graphviz/setup-graphviz@v2
-      - uses: Gr1N/setup-poetry@v8
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.12"
-          cache: "poetry"
-      - name: Setup the project
-        run: poetry install
-      - name: Lint markdown files
-        run: just lint-md
-      - name: Lint Python files
-        run: just lint-python
-      - name: Lint the docs
-        run: just docs
+permissions:
+  # This is required for requesting the JWT.
+  id-token: write
+  # This is required for actions/checkout.
+  contents: read
 
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v1
-      - uses: Gr1N/setup-poetry@v8
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.12"
-          cache: "poetry"
-      - name: Setup host
-        run: poetry install
-      - name: Setup the project
-        run: poetry install
-      - name: Run the unit tests
-        run: just test
+jobs:
+  ci:
+    uses: PeopleForBikes/.github/.github/workflows/ci-python.yml@main

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,7 +8,7 @@ on:
       - reopened
 
 jobs:
-  runner-job:
+  integration:
     runs-on: ubuntu-latest
 
     env:
@@ -31,9 +31,9 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
-      - uses: Gr1N/setup-poetry@v8
-      - uses: actions/setup-python@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: Gr1N/setup-poetry@48b0f77c8c1b1b19cb962f0f00dff7b4be8f81ec # v9
+      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: "3.12"
           cache: "poetry"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
   docker:
     uses: PeopleForBikes/.github/.github/workflows/docker-build-publish-ghcr.yml@main
     with:
-      push-to-ghcr: false
+      push-to-ghcr: true
       push-to-ecr: true
       aws-region: us-west-2
     secrets:
@@ -24,9 +24,9 @@ jobs:
   release-dist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: Gr1N/setup-poetry@v8
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: Gr1N/setup-poetry@48b0f77c8c1b1b19cb962f0f00dff7b4be8f81ec # v9
+      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: "3.12"
           cache: "poetry"


### PR DESCRIPTION
Updates the deployment workflow to publish our Docker images to both
GitHub and AWS.

Drive-by:
- Leverages the reusable workflows.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>