### PR TITLE
Change neighborhood_reachable_roads_low_stress to neighborhood_reachable_roads_high_stress in connected census blocks calculation

### DIFF
--- a/brokenspoke_analyzer/scripts/sql/connectivity/connected_census_blocks.sql
+++ b/brokenspoke_analyzer/scripts/sql/connectivity/connected_census_blocks.sql
@@ -34,7 +34,7 @@ SELECT
     TRUE, -- noqa: AL03
     (
         SELECT MIN(hs.total_cost)
-        FROM neighborhood_reachable_roads_low_stress AS hs
+        FROM neighborhood_reachable_roads_high_stress AS hs
         WHERE
             hs.base_road = ANY(source.road_ids)
             AND hs.target_road = ANY(target.road_ids)


### PR DESCRIPTION
# Pull-Request

Thank you for all of the work that goes into the ratings! I have been working on understanding how the scores work and running them locally and came across what I think is a bug.

## Types of changes

<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Description

This changes the table used when calculating census block connection scores. The second clause seemed like it was intended to be using the `neighborhood_reachable_roads_high_stress` table with the TRUE `high_stress` value and `hs` alias for the table. I'm not 100% sure, but I figured this could impact calculated scores if that was the case, so I wanted to open this to confirm first.

I've run the unit tests locally and they passed. I have also tested it manually on some smaller cities I'm familiar with, and in general the scores seem to be lower with this change, but still near the results on https://cityratings.peopleforbikes.org/.

I'm very much interested in helping where I can with this tool, so if there's anything I can do, just let me know. Thanks again for making this!

<!--
Motivation and Context
Why is this change required? What problem does it solve?
-->

<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

- [x] I have updated the documentation accordingly
- [ ] I have updated the Changelog (if applicable)

<!--
Place the URL of the issue here if this PR fixes an existing issue.
Use either the `username/repository#` syntax (preferred) or the *FULL* URL.

Fixes: PeopleForBikes/PeopleForBikes.github.io#
-->
