### PR TITLE
Fix Dockerfile

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,8 +14,6 @@ permissions:
   packages: write
 
 jobs:
-  release:
-    uses: PeopleForBikes/.github/.github/workflows/release-python.yml@main
   docker:
     uses: PeopleForBikes/.github/.github/workflows/docker-build-publish-ghcr.yml@main
     with:
@@ -24,6 +22,11 @@ jobs:
       aws-region: us-west-2
     secrets:
       github-role: ${{ secrets.FEDERATED_GITHUB_ROLE_ARN_STAGING }}
+
+  release:
+    needs:
+      - docker
+    uses: PeopleForBikes/.github/.github/workflows/release-python.yml@main
 
   release-dist:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM python:3.12.2-slim-bookworm AS builder
+FROM python:3.12.4-slim-bookworm AS base
 
+FROM base AS builder
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   gcc \
@@ -13,17 +14,13 @@ RUN apt-get update \
 WORKDIR /usr/src/app
 COPY . .
 RUN poetry self update \
-  && poetry export -f requirements.txt --output requirements.txt \
-  && mkdir -p deps \
-  && pip wheel -r requirements.txt -w deps \
   && poetry build -f wheel
 
-FROM python:3.12.2-slim-bookworm
+FROM base
 LABEL author="PeopleForBikes" \
   maintainer="BNA Mechanics - https://peopleforbikes.github.io" \
   org.opencontainers.image.description="Run a BNA analysis locally." \
   org.opencontainers.image.source="https://github.com/PeopleForBikes/brokenspoke-analyzer"
-
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   gdal-bin \
@@ -35,14 +32,10 @@ RUN apt-get update \
   postgis \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-ENV BNA_OSMNX_CACHE 0
+ENV BNA_OSMNX_CACHE=0
 WORKDIR /usr/src/app
-COPY --from=builder /usr/src/app/deps ./pkg/deps
 COPY --from=builder /usr/src/app/dist ./pkg/dist
-RUN pip install pkg/deps/fiona-1.9.5-*.whl \
-  && pip install pkg/deps/* \
-  && pip install pkg/dist/brokenspoke_analyzer-*-py3-none-any.whl \
+RUN pip install pkg/dist/brokenspoke_analyzer-*-py3-none-any.whl \
   && rm -fr /usr/src/app/pkg \
   && addgroup --system --gid 1001 bna \
   && adduser --system --uid 1001 bna \


### PR DESCRIPTION
Fixes the Dockerfile as GeoPandas 1.0.0 does not need Fiona as the I/O
engine, and as a result, we can get rid of the workaround that was
needed to install the brokenspoke analyzer.

Drive-by:
- Reorders the CI steps in the release workflow to ensure the Docker
  image builds before creating the release.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
