### PR TITLE
Add Dev container for local development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "name": "pfb/brokenspoke-analyzer",
+  "dockerComposeFile": ["../compose.yml"],
+  "service": "bna-dev",
+  "runServices": ["bna-dev", "postgres"],
+  "workspaceFolder": "/usr/src/app",
+  "postAttachCommand": ["/bin/bash", ".devcontainer/postAttach.sh"],
+  "customizations": {
+    "vscode": {
+      // Set *default* container specific settings.json values on container create.
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "terminal.integrated.profiles.linux": {
+          "bash": {
+            "path": "/bin/bash"
+          }
+        }
+      },
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+        "eamodio.gitlens",
+        "esbenp.prettier-vscode",
+        "mhutchie.git-graph",
+        "ms-python.python"
+      ]
+    }
+  }
+}

--- a/.devcontainer/postAttach.sh
+++ b/.devcontainer/postAttach.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eu
+
+echo 'source /etc/bash_completion.d/git-completion.bash' >> ~/.bashrc
+echo 'export LANG=C.UTF-8' >> ~/.bashrc
+echo 'export LC_ALL=C.UTF-8' >> ~/.bashrc

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,12 @@ The Brokenspoke-analyzer project follows the
 [BNA Mechanics Contributing Guidelines](https://peopleforbikes.github.io/contributing/).
 Refer to them for general principles.
 
-Specific instructions will be described in other sections on this page.
+In the sections below we provide instructions for how to set up a
+[developer environment locally](Developer_environment) or using a
+[development container](Development_container). Specific instructions will be
+described in other sections on this page.
+
+(Developer_environment)=
 
 ## Developer environment
 
@@ -57,6 +62,8 @@ Then open the <http://127.0.0.1:1111> URL to view the site.
 
 The content will automatically be refreshed when a file is saved on disk.
 
+(Administration_tasks)=
+
 ## Administration tasks
 
 Administration tasks are being provided as convenience in a `justfile`.
@@ -101,3 +108,43 @@ uv run bna run usa "santa rosa" "new mexico" 3570670
 ```
 
 [brokenspoke-analyzer]: https://github.com/PeopleForBikes/brokenspoke-analyzer
+
+(Development_container)=
+
+## Development Container
+
+This method provides a replicable developer and debugging environment based on a
+VSCode development container.
+
+In the development container's terminal, export the database URL:
+
+```bash
+export DATABASE_URL=postgresql://postgres:postgres@postgres:5432/postgres
+```
+
+Build and open the application in a development container in VS Code by running
+the command `Dev Containers: Rebuild and Reopen in Container` via the command
+palette (⇧⌘P in Mac or `Ctrl+Shift+P` in Windows). The database will be started
+in the background and once the development container opens, a terminal will be
+available to run the analyzer.
+
+In the development container's terminal, configure the database:
+
+```bash
+bna -vv configure custom 4 4096 postgres
+```
+
+Run the analysis:
+
+```bash
+bna -vv run "united states" "santa rosa" "new mexico" 3570670
+```
+
+After the analysis runs, by default, the results will be exported locally.
+
+All the [administration tasks](Administration_tasks) can also be ran inside the
+development container.
+
+Close the container and return to your local environment by running the command
+`Dev Containers: Reopen Folder Locally` via the command palette (⇧⌘P in Mac or
+`Ctrl+Shift+P` in Windows). The database will be stopped.

--- a/compose.yml
+++ b/compose.yml
@@ -1,3 +1,5 @@
+name: brokenspoke-analyzer
+
 services:
   postgres:
     image: ghcr.io/peopleforbikes/docker-postgis-bna:17-3.4-1
@@ -18,7 +20,28 @@ services:
       - 5432:5432
     volumes:
       - postgres:/var/lib/postgresql/data
+    networks:
+      - default
+
+  bna-dev:
+    profiles:
+      - dev
+    build:
+      context: .
+      target: dev
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres
+    image: ghcr.io/peopleforbikes/brokenspoke-analyzer:dev
+    entrypoint: sleep infinity
+    volumes:
+      - ./:/usr/src/app
+    networks:
+      - default
 
 volumes:
   postgres:
     external: false
+
+networks:
+  default:
+    driver: bridge

--- a/justfile
+++ b/justfile
@@ -1,6 +1,7 @@
 set positional-arguments := true
 
 src_dir := "brokenspoke_analyzer"
+docker_image := "ghcr.io/peopleforbikes/brokenspoke-analyzer"
 
 # Meta task running ALL the CI tasks at onces.
 ci: lint docs test
@@ -62,7 +63,11 @@ docs-clean:
 
 # Build the Docker image for local usage.
 docker-build:
-    docker buildx build -t ghcr.io/peopleforbikes/brokenspoke-analyzer:dev --load .
+    docker buildx build -t {{ docker_image }} --load .
+
+# Build the dev container.
+docker-build-devcontainer:
+    docker buildx build -t {{ docker_image }}:dev --target dev --load .
 
 docker-prepare-all *args:
     echo "$@"
@@ -74,10 +79,15 @@ docker-prepare-all *args:
       --output-dir /usr/src/app/data \
       "$@"
 
-# Clean up docker resources.
-compose-clean:
-    docker-compose rm -sfv
-    docker volume rm brokenspoke-analyzer_postgres
+# Spin up Docker Compose.
+compose-up:
+  docker compose up -d
+
+# Tear down Docker Compose.
+compose-down:
+  docker compose down
+  docker compose rm -sfv
+  docker volume rm -f brokenspoke-analyzer_postgres
 
 # Setup the project
 setup:


### PR DESCRIPTION
This draft PR will be used to see if a development container helps simplify setting up a local environment for a developer/analyst.
To run the development container, follow the instructions in [Development Container](https://github.com/PeopleForBikes/brokenspoke-analyzer/blob/fc3f3de520053ac75157bbb46e679ceb86402b70/README.md?plain=1#L143).