### PR TITLE
Update Docker Compose

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,14 +1,13 @@
-version: "3"
 services:
   postgres:
-    image: ghcr.io/peopleforbikes/docker-postgis-bna:13-3.1-1
+    image: ghcr.io/peopleforbikes/docker-postgis-bna:17-3.4-1
     shm_size: 1g
     environment:
-        POSTGRES_PASSWORD: postgres
-        POSTGRES_USER: postgres
-        POSTGRESQL_USERNAME: bna
-        POSTGRESQL_PASSWORD: bna
-        POSTGRESQL_DATABASE: bna
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRESQL_USERNAME: bna
+      POSTGRESQL_PASSWORD: bna
+      POSTGRESQL_DATABASE: bna
     healthcheck:
       test: ["CMD", "pg_isready"]
       interval: 10s
@@ -18,7 +17,7 @@ services:
     ports:
       - 5432:5432
     volumes:
-        - postgres:/var/lib/postgresql/data
+      - postgres:/var/lib/postgresql/data
 
 volumes:
   postgres:


### PR DESCRIPTION
Update Docker Compose to use the latest BNA image for
PostgreSQL/PostGIS.

Drive-by:
- Fixes configuration warnings.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
