### PR TITLE
Export all tables as GeoJSON

### DIFF
--- a/brokenspoke_analyzer/core/exporter.py
+++ b/brokenspoke_analyzer/core/exporter.py
@@ -35,6 +35,8 @@ TABLE_CATALOG = {
         "neighborhood_supermarkets",
         "neighborhood_transit",
         "neighborhood_universities",
+        "neighborhood_ways",
+        "neighborhood_ways_intersections",
     ],
     "csv": [
         "neighborhood_connected_census_blocks",


### PR DESCRIPTION
Exports all tables as GeoJSON.

Drive-by:
- Adds the intersections tables.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
