### PR TITLE
Do not move tables to received schema

### DIFF
--- a/brokenspoke_analyzer/core/ingestor.py
+++ b/brokenspoke_analyzer/core/ingestor.py
@@ -461,10 +461,6 @@ def import_osm_data(
         city_speed_limit_override,
     )
 
-    # Move the full osm tables to the received schema.
-    logger.debug("Moving tables to received schema...")
-    move_tables(engine)
-
 
 def import_all(
     engine: Engine,


### PR DESCRIPTION
Does not move the full OSM tables to the received schema.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
