### PR TITLE
Update width calculations in width_ft.sql

### DIFF
--- a/brokenspoke_analyzer/scripts/sql/features/width_ft.sql
+++ b/brokenspoke_analyzer/scripts/sql/features/width_ft.sql
@@ -13,6 +13,17 @@ WHERE
     AND osm.width IS NOT NULL
     AND osm.width LIKE '% ft';
 
+-- feet specified as X'Y" OR X'
+UPDATE neighborhood_ways
+SET
+    width_ft = substring(osm.width FROM '(\d+)''')::FLOAT
+    + coalesce(substring(osm.width FROM '(\d+)"')::FLOAT / 12, 0)
+FROM neighborhood_osm_full_line AS osm
+WHERE
+    neighborhood_ways.osm_id = osm.osm_id
+    AND osm.width IS NOT NULL
+    AND (osm.width LIKE '%''%"' OR osm.width LIKE '%''');
+
 -- meters
 UPDATE neighborhood_ways
 SET width_ft = 3.28084 * substring(osm.width FROM '\d+\.?\d?\d?')::FLOAT
@@ -30,5 +41,6 @@ SET width_ft = 3.28084 * substring(osm.width FROM '\d+\.?\d?\d?')::FLOAT
 FROM neighborhood_osm_full_line AS osm
 WHERE
     neighborhood_ways.osm_id = osm.osm_id
+    AND neighborhood_ways.width_ft IS NULL
     AND osm.width IS NOT NULL
     AND substring(osm.width FROM '\d+\.?\d?\d?')::FLOAT < 20;


### PR DESCRIPTION
# Pull-Request

## Types of changes

<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Description

This PR intends to make a couple changes around the calculation of `width_ft` from OSM widths. Both are related to the fallback case of multiplying the width by 3.28084 when no units are specified. The first tries to capture cases where the width is expressed in feet and inches using single and double quotes.

The second adds a null check to not update `width_ft` if it has already been set. I noticed that paths with an OSM width of say `8 ft` were being multiplied to become 26 ft.

Example:

```sql
SELECT width_ft, osm.width from neighborhood_ways nw
JOIN neighborhood_osm_full_line osm ON osm.osm_id = nw.osm_id;

--  width_ft | width
-- ----------+-------
--        33 | 10 ft
--        33 | 10'
--        26 | 8'
--        29 | 29'4"
--        33 | 10'
--        30 | 9'4"
--        33 | 10'
--        39 | 12 ft
--        39 | 12 ft
```

<!--
Describe your changes in detail.
Add a screenshot if applicable.
-->

<!--
Motivation and Context
Why is this change required? What problem does it solve?
-->

<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

- [x] I have updated the documentation accordingly
- [ ] I have updated the Changelog (if applicable)
