### PR TITLE
Use new format for street parking tagging

### DIFF
--- a/brokenspoke_analyzer/scripts/pfb.style
+++ b/brokenspoke_analyzer/scripts/pfb.style
@@ -130,6 +130,15 @@ way        parking:lane:width        text  linear
 way        parking:lane:right:width  text  linear
 way        parking:lane:left:width   text  linear
 way        parking:lane:both:width   text  linear
+way        parking:right  text  linear
+way        parking:left   text  linear
+way        parking:both   text  linear
+way        parking:right:restriction  text  linear
+way        parking:left:restriction   text  linear
+way        parking:both:restriction   text  linear
+way        parking:right:width  text  linear
+way        parking:left:width   text  linear
+way        parking:both:width   text  linear
 node,way   public_transport    text  linear,polygon
 node,way   railway      text         linear,polygon
 node,way   segregated   text         linear

--- a/brokenspoke_analyzer/scripts/sql/features/park.sql
+++ b/brokenspoke_analyzer/scripts/sql/features/park.sql
@@ -15,6 +15,10 @@ SET
         WHEN osm."parking:lane:both" = 'perpendicular' THEN 1
         WHEN osm."parking:lane:both" = 'no_parking' THEN 0
         WHEN osm."parking:lane:both" = 'no_stopping' THEN 0
+        WHEN osm."parking:both" = 'lane' THEN 1
+        WHEN osm."parking:both" = 'no' THEN 0
+        WHEN osm."parking:both:restriction" = 'no_stopping' THEN 0
+        WHEN osm."parking:both:restriction" = 'no_parking' THEN 0
     END,
     tf_park = CASE
         WHEN osm."parking:lane:both" = 'parallel' THEN 1
@@ -23,6 +27,10 @@ SET
         WHEN osm."parking:lane:both" = 'perpendicular' THEN 1
         WHEN osm."parking:lane:both" = 'no_parking' THEN 0
         WHEN osm."parking:lane:both" = 'no_stopping' THEN 0
+        WHEN osm."parking:both" = 'lane' THEN 1
+        WHEN osm."parking:both" = 'no' THEN 0
+        WHEN osm."parking:both:restriction" = 'no_stopping' THEN 0
+        WHEN osm."parking:both:restriction" = 'no_parking' THEN 0
     END
 FROM neighborhood_osm_full_line AS osm
 WHERE neighborhood_ways.osm_id = osm.osm_id;
@@ -37,6 +45,10 @@ SET
         WHEN osm."parking:lane:right" = 'perpendicular' THEN 1
         WHEN osm."parking:lane:right" = 'no_parking' THEN 0
         WHEN osm."parking:lane:right" = 'no_stopping' THEN 0
+        WHEN osm."parking:right" = 'lane' THEN 1
+        WHEN osm."parking:right" = 'no' THEN 0
+        WHEN osm."parking:right:restriction" = 'no_stopping' THEN 0
+        WHEN osm."parking:right:restriction" = 'no_parking' THEN 0
     END
 FROM neighborhood_osm_full_line AS osm
 WHERE neighborhood_ways.osm_id = osm.osm_id;
@@ -51,6 +63,10 @@ SET
         WHEN osm."parking:lane:left" = 'perpendicular' THEN 1
         WHEN osm."parking:lane:left" = 'no_parking' THEN 0
         WHEN osm."parking:lane:left" = 'no_stopping' THEN 0
+        WHEN osm."parking:left" = 'lane' THEN 1
+        WHEN osm."parking:left" = 'no' THEN 0
+        WHEN osm."parking:left:restriction" = 'no_stopping' THEN 0
+        WHEN osm."parking:left:restriction" = 'no_parking' THEN 0
     END
 FROM neighborhood_osm_full_line AS osm
 WHERE neighborhood_ways.osm_id = osm.osm_id;


### PR DESCRIPTION
# Pull-Request

## Types of changes

<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Description

The structure for tagging on-street parking changed towards the end of 2022. [parking:lane](https://wiki.openstreetmap.org/wiki/Key:parking:lane) and friends was deprecated in favor of [parking:side](https://wiki.openstreetmap.org/wiki/Street_parking#To_migrate_deprecated_parking:lane=*_and_parking:condition=*_tags). The changes here attempt to capture that. I wasn't sure if the deprecated tagging should be kept or removed. It seemed like most parking tags have been updated, so I opted to not, but can re-add it if it's preferred.

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the Changelog (if applicable)
