### PR TITLE
Buffer city boundaries for clipping OSM data

### DIFF
--- a/brokenspoke_analyzer/cli/prepare.py
+++ b/brokenspoke_analyzer/cli/prepare.py
@@ -40,6 +40,7 @@ def all(
     block_population: common.BlockPopulation = common.DEFAULT_BLOCK_POPULATION,
     retries: common.Retries = common.DEFAULT_RETRIES,
     lodes_year: common.LODESYear = common.DEFAULT_LODES_YEAR,
+    buffer: common.Buffer = common.DEFAULT_BUFFER,
 ) -> None:
     """Prepare all the files required for an analysis."""
     # Make MyPy happy.
@@ -55,6 +56,8 @@ def all(
         raise ValueError("`retries` must be set")
     if not lodes_year:
         raise ValueError("`lodes_year` must be set")
+    if not buffer:
+        raise ValueError("`buffer` must be set")
 
     # Handles us/usa as the same country.
     if country.upper() == "US":
@@ -80,6 +83,7 @@ def all(
             block_population=block_population,
             retries=retries,
             lodes_year=lodes_year,
+            buffer=buffer,
         )
     )
 
@@ -93,6 +97,7 @@ async def prepare_(
     block_population: int,
     retries: int,
     lodes_year: int,
+    buffer: int,
     region: typing.Optional[str] = None,
 ) -> None:
     """Prepare and kicks off the analysis."""
@@ -116,7 +121,7 @@ async def prepare_(
     # Retrieve city boundaries.
     with console.status("[bold green]Querying OSM to retrieve the city boundaries..."):
         slug = retryer(
-            analysis.retrieve_city_boundaries, output_dir, country, city, region
+            analysis.retrieve_city_boundaries, output_dir, buffer, country, city, region
         )
         boundary_file = output_dir / f"{slug}.shp"
         console.log("Boundary files ready.")
@@ -140,7 +145,7 @@ async def prepare_(
 
     # Reduce the osm file with osmium.
     with console.status(f"[bold green]Reducing the OSM file for {city} with osmium..."):
-        polygon_file = output_dir / f"{slug}.geojson"
+        polygon_file = output_dir / f"buffered_{slug}.geojson"
         pfb_osm_file = pathlib.Path(f"{slug}.osm")
         analysis.prepare_city_file(
             output_dir, region_file_path, polygon_file, pfb_osm_file


### PR DESCRIPTION
# Pull-Request

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to
  change)
- Code cleanup / Refactoring
- Documentation
- Infrastructure and automation

## Description

Currently the roads imported look to be limited to the city's boundaries. It looked like previous versions of the analysis included some buffer. This PR attempts to add some buffer to the city boundaries for the import of OSM data. I'm not sure on my approach to adding the buffer, though I hope it is in roughly the right area.

I've included a before/after example of Glendale, WI, which has some more interesting boundaries where a more strict import of the boundaries can exclude destinations and routes that may be convenient. The city area is shaded pink with the different roads imported shown in the before and after using a buffer of the default distance of 2680 meters.

| Before | After |
|-----|-----|
| <img width="346" alt="image" src="https://github.com/user-attachments/assets/6d46dd12-dd4f-479c-9ef4-7d77290dd280" /> | <img width="528" alt="image" src="https://github.com/user-attachments/assets/6c3a941a-1f70-4829-a3b2-356f90401b20" /> |


<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the Changelog (if applicable)