### PR TITLE
Fix --export-dir option

### DIFF
--- a/brokenspoke_analyzer/cli/run_with.py
+++ b/brokenspoke_analyzer/cli/run_with.py
@@ -61,6 +61,7 @@ def compose(
             city=city,
             region=region,
             output_dir=output_dir,
+            export_dir=export_dir,
             fips_code=fips_code,
             buffer=buffer,
             city_speed_limit=city_speed_limit,


### PR DESCRIPTION
Ensures the `--export-dir` option is honored by the analyzer.

Fixes PeopleForBikes/brokenspoke-analyzer#819

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
