### PR TITLE
Remove unused column and indices in neighborhood_connected_census_blocks table

### DIFF
--- a/brokenspoke_analyzer/scripts/sql/connectivity/connected_census_blocks.sql
+++ b/brokenspoke_analyzer/scripts/sql/connectivity/connected_census_blocks.sql
@@ -7,7 +7,6 @@
 DROP TABLE IF EXISTS generated.neighborhood_connected_census_blocks;
 
 CREATE TABLE generated.neighborhood_connected_census_blocks (
-    id SERIAL PRIMARY KEY,
     source_blockid10 VARCHAR(15),
     target_blockid10 VARCHAR(15),
     low_stress BOOLEAN,
@@ -74,10 +73,6 @@ ON neighborhood_connected_census_blocks (
 );
 CREATE INDEX IF NOT EXISTS idx_neighborhood_blockpairs_lstress
 ON neighborhood_connected_census_blocks (
-    low_stress
-) WHERE low_stress IS TRUE;
-CREATE INDEX IF NOT EXISTS idx_neighborhood_blockpairs_hstress
-ON neighborhood_connected_census_blocks (
-    high_stress
-) WHERE high_stress IS TRUE;
+    source_blockid10, target_blockid10, low_stress
+);
 ANALYZE neighborhood_connected_census_blocks;


### PR DESCRIPTION
# Pull-Request

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to
  change)
- Code cleanup / Refactoring
- Documentation
- Infrastructure and automation

## Description

I came across this while working on #821. This removes the `id` column and `idx_neighborhood_blockpairs_hstress` index on the `neighborhood_connected_census_blocks` table as neither are currently used. The `idx_neighborhood_blockpairs_lstress` index is also not currently used, so it is slightly modified so that it can be used in the `_access` SQL queries. As an example in Wauwatosa, WI, the query to update `neighborhood_connected_census_blocks` with `schools_and_stress` `schools_low_stress` only uses the original `idx_neighborhood_blockpairs` index in the current implementation.

```sql
-- Update Statement from brokenspoke_analyzer/scripts/sql/connectivity/access_schools.sql
EXPLAIN ANALYZE UPDATE neighborhood_census_blocks
SET
    schools_low_stress = (
        SELECT COUNT(id)
        FROM neighborhood_schools
        WHERE EXISTS (
            SELECT 1
            FROM neighborhood_connected_census_blocks
            WHERE
                neighborhood_connected_census_blocks.source_blockid10
                = neighborhood_census_blocks.blockid10
                AND neighborhood_connected_census_blocks.target_blockid10
                = ANY(neighborhood_schools.blockid10)
                AND neighborhood_connected_census_blocks.low_stress
        )
    ),
    schools_high_stress = (
        SELECT COUNT(id)
        FROM neighborhood_schools
        WHERE EXISTS (
            SELECT 1
            FROM neighborhood_connected_census_blocks
            WHERE
                neighborhood_connected_census_blocks.source_blockid10
                = neighborhood_census_blocks.blockid10
                AND neighborhood_connected_census_blocks.target_blockid10
                = ANY(neighborhood_schools.blockid10)
        )
    )
WHERE EXISTS (
    SELECT 1
    FROM neighborhood_boundary AS b
    WHERE ST_Intersects(neighborhood_census_blocks.geom, b.geom)
);
```

```
                                                                                                                 QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Update on neighborhood_census_blocks  (cost=0.00..89747.71 rows=0 width=0) (actual time=764.100..764.101 rows=0 loops=1)
   ->  Nested Loop Semi Join  (cost=0.00..89747.71 rows=4 width=20) (actual time=4.225..750.335 rows=1019 loops=1)
         Join Filter: st_intersects(neighborhood_census_blocks.geom, b.geom)
         Rows Removed by Join Filter: 3044
         ->  Seq Scan on neighborhood_census_blocks  (cost=0.00..37229.81 rows=4081 width=406) (actual time=0.029..39.899 rows=4063 loops=1)
         ->  Materialize  (cost=0.00..1.01 rows=1 width=38) (actual time=0.000..0.000 rows=1 loops=4063)
               ->  Seq Scan on neighborhood_boundary b  (cost=0.00..1.01 rows=1 width=38) (actual time=0.007..0.008 rows=1 loops=1)
         SubPlan 1
           ->  Aggregate  (cost=286.12..286.13 rows=1 width=8) (actual time=0.361..0.361 rows=1 loops=1019)
                 ->  Nested Loop Semi Join  (cost=0.42..286.11 rows=6 width=4) (actual time=0.183..0.360 rows=3 loops=1019)
                       ->  Seq Scan on neighborhood_schools  (cost=0.00..5.26 rows=26 width=51) (actual time=0.000..0.001 rows=26 loops=1019)
                       ->  Index Scan using idx_neighborhood_blockpairs on neighborhood_connected_census_blocks  (cost=0.42..10.95 rows=1 width=16) (actual time=0.014..0.014 rows=0 loops=26494)
                             Index Cond: (((source_blockid10)::text = (neighborhood_census_blocks.blockid10)::text) AND ((target_blockid10)::text = ANY ((neighborhood_schools.blockid10)::text[])))
                             Filter: low_stress
                             Rows Removed by Filter: 0
         SubPlan 2
           ->  Aggregate  (cost=77.20..77.21 rows=1 width=8) (actual time=0.332..0.333 rows=1 loops=1019)
                 ->  Nested Loop Semi Join  (cost=0.42..77.14 rows=24 width=4) (actual time=0.064..0.332 rows=11 loops=1019)
                       ->  Seq Scan on neighborhood_schools neighborhood_schools_1  (cost=0.00..5.26 rows=26 width=51) (actual time=0.000..0.001 rows=26 loops=1019)
                       ->  Index Only Scan using idx_neighborhood_blockpairs on neighborhood_connected_census_blocks neighborhood_connected_census_blocks_1  (cost=0.42..4.46 rows=2 width=16) (actual time=0.013..0.013 rows=0 loops=26494)
                             Index Cond: ((source_blockid10 = (neighborhood_census_blocks.blockid10)::text) AND (target_blockid10 = ANY ((neighborhood_schools_1.blockid10)::text[])))
                             Heap Fetches: 0
 Planning Time: 0.921 ms
 Execution Time: 764.195 ms
```

SubPlan 1 is querying for the low stress connected census blocks, but it has to do an `Index Scan` rather than the faster `Index Only Scan` that SubPlan2 can use because it doesn't need to filter on `low_stress`.

After adding the new version of `idx_neighborhood_blockpairs_lstress`, both SubPlans can use an `Index Only Scan`, resulting in a faster query. 

```
                                                                                                                     QUERY PLAN                                                                                                                    
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Update on neighborhood_census_blocks  (cost=0.00..87983.14 rows=0 width=0) (actual time=636.670..636.671 rows=0 loops=1)
   ->  Nested Loop Semi Join  (cost=0.00..87983.14 rows=4 width=20) (actual time=3.111..622.771 rows=1019 loops=1)
         Join Filter: st_intersects(neighborhood_census_blocks.geom, b.geom)
         Rows Removed by Join Filter: 3044
         ->  Seq Scan on neighborhood_census_blocks  (cost=0.00..37229.08 rows=4008 width=421) (actual time=0.014..39.632 rows=4063 loops=1)
         ->  Materialize  (cost=0.00..1.01 rows=1 width=38) (actual time=0.000..0.000 rows=1 loops=4063)
               ->  Seq Scan on neighborhood_boundary b  (cost=0.00..1.01 rows=1 width=38) (actual time=0.006..0.007 rows=1 loops=1)
         SubPlan 1
           ->  Aggregate  (cost=73.51..73.52 rows=1 width=8) (actual time=0.228..0.228 rows=1 loops=1019)
                 ->  Nested Loop Semi Join  (cost=0.42..73.50 rows=6 width=4) (actual time=0.103..0.227 rows=3 loops=1019)
                       Join Filter: ((neighborhood_connected_census_blocks.target_blockid10)::text = ANY ((neighborhood_schools.blockid10)::text[]))
                       Rows Removed by Join Filter: 2251
                       ->  Seq Scan on neighborhood_schools  (cost=0.00..5.26 rows=26 width=51) (actual time=0.000..0.001 rows=26 loops=1019)
                       ->  Materialize  (cost=0.42..33.93 rows=98 width=16) (actual time=0.001..0.004 rows=87 loops=26494)
                             ->  Index Only Scan using idx_neighborhood_blockpairs_lstress on neighborhood_connected_census_blocks  (cost=0.42..33.44 rows=98 width=16) (actual time=0.021..0.046 rows=96 loops=1019)
                                   Index Cond: ((source_blockid10 = (neighborhood_census_blocks.blockid10)::text) AND (low_stress = true))
                                   Heap Fetches: 0
         SubPlan 2
           ->  Aggregate  (cost=77.20..77.21 rows=1 width=8) (actual time=0.340..0.340 rows=1 loops=1019)
                 ->  Nested Loop Semi Join  (cost=0.42..77.14 rows=24 width=4) (actual time=0.065..0.339 rows=11 loops=1019)
                       ->  Seq Scan on neighborhood_schools neighborhood_schools_1  (cost=0.00..5.26 rows=26 width=51) (actual time=0.000..0.001 rows=26 loops=1019)
                       ->  Index Only Scan using idx_neighborhood_blockpairs_lstress on neighborhood_connected_census_blocks neighborhood_connected_census_blocks_1  (cost=0.42..4.46 rows=2 width=16) (actual time=0.013..0.013 rows=0 loops=26494)
                             Index Cond: ((source_blockid10 = (neighborhood_census_blocks.blockid10)::text) AND (target_blockid10 = ANY ((neighborhood_schools_1.blockid10)::text[])))
                             Heap Fetches: 0
 Planning Time: 2.554 ms
 Execution Time: 636.772 ms
```

The new index does end up being a slightly larger than the space saved on the older indexes and primary key column, but I think the computation time savings are worthwhile.

<!--
Motivation and Context
Why is this change required? What problem does it solve?
-->

<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the Changelog (if applicable)

<!--
Place the URL of the issue here if this PR fixes an existing issue.
Use either the `username/repository#` syntax (preferred) or the *FULL* URL.
-->
