### PR TITLE
Add ability to run partial analysis

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -51,7 +51,8 @@ jobs:
             osm2pgrouting osm2pgsql osmctools osmium-tool postgresql-client postgis
       - name: Setup the project
         run: uv sync --all-extras --dev
-      - run: |
+      - name: Run analysis
+        run: |
           uv run bna configure docker
           # uv run bna run "${{ env.TEST_COUNTRY }}" "${{ env.TEST_CITY }}" "${{ env.TEST_STATE }}" "${{ env.TEST_FIPS }}"
           uv run bna prepare all "${{ env.TEST_COUNTRY }}" "${{ env.TEST_CITY }}" "${{ env.TEST_STATE }}" "${{ env.TEST_FIPS }}"

--- a/brokenspoke_analyzer/cli/common.py
+++ b/brokenspoke_analyzer/cli/common.py
@@ -6,6 +6,8 @@ import typing
 import typer
 from typing_extensions import Annotated
 
+from brokenspoke_analyzer.core import constant
+
 # Default constants.
 DEFAULT_BLOCK_POPULATION = 100
 DEFAULT_BLOCK_SIZE = 500
@@ -19,6 +21,7 @@ DEFAULT_OUTPUT_DIR = pathlib.Path("./data")
 DEFAULT_EXPORT_DIR = pathlib.Path("./results")
 DEFAULT_RETRIES = 2
 DEFAULT_MAX_TRIP_DISTANCE = 2680
+DEFAULT_COMPUTE_PARTS = constant.COMPUTE_PARTS_ALL
 
 # Default Typer Arguments/Options.
 BlockPopulation = Annotated[
@@ -34,6 +37,10 @@ LODESYear = Annotated[
     typing.Optional[int], typer.Option(help="year to use to retrieve US job data")
 ]
 City = Annotated[str, typer.Argument()]
+ComputeParts = Annotated[
+    typing.Optional[typing.List[constant.ComputePart]],
+    typer.Option(help="parts of the analysis to compute"),
+]
 ContainerName = Annotated[
     typing.Optional[str],
     typer.Option(help="give a specific name to the container running the BNA"),

--- a/brokenspoke_analyzer/cli/root.py
+++ b/brokenspoke_analyzer/cli/root.py
@@ -25,7 +25,6 @@ from brokenspoke_analyzer.cli import (
 from brokenspoke_analyzer.core import (
     analysis,
     compute,
-    constant,
     exporter,
     ingestor,
     utils,
@@ -114,6 +113,7 @@ def compute_cmd(
     city: common.City,
     region: common.Region = None,
     buffer: common.Buffer = common.DEFAULT_BUFFER,
+    with_parts: common.ComputeParts = common.DEFAULT_COMPUTE_PARTS,
 ) -> None:
     """Run an analysis."""
     # Make MyPy happy.
@@ -143,7 +143,7 @@ def compute_cmd(
 
     console = Console()
     with console.status("[bold green]Running the full analysis (may take a while)..."):
-        compute.all(
+        compute.parts(
             database_url=database_url,
             sql_script_dir=sql_script_dir,
             output_srid=output_srid,
@@ -176,6 +176,7 @@ def run(
     ] = None,
     s3_dir: typing.Optional[pathlib.Path] = None,
     with_bundle: typing.Optional[bool] = False,
+    with_parts: common.ComputeParts = common.DEFAULT_COMPUTE_PARTS,
 ) -> None:
     """Run an analysis."""
     run_with.run_(
@@ -196,4 +197,5 @@ def run(
         s3_bucket=s3_bucket,
         s3_dir=s3_dir,
         with_bundle=with_bundle,
+        with_parts=with_parts,
     )

--- a/brokenspoke_analyzer/cli/run_with.py
+++ b/brokenspoke_analyzer/cli/run_with.py
@@ -49,6 +49,7 @@ def compose(
     with_export: typing.Optional[exporter.Exporter] = exporter.Exporter.local,
     s3_bucket: typing.Optional[str] = None,
     with_bundle: typing.Optional[bool] = False,
+    with_parts: common.ComputeParts = common.DEFAULT_COMPUTE_PARTS,
 ) -> typing.Optional[pathlib.Path]:
     """Manage Docker Compose when running the analysis."""
     database_url = "postgresql://postgres:postgres@localhost:5432/postgres"
@@ -73,6 +74,7 @@ def compose(
             with_export=with_export,
             s3_bucket=s3_bucket,
             with_bundle=with_bundle,
+            with_parts=with_parts,
         )
     finally:
         subprocess.run(["docker", "compose", "rm", "-sfv"], check=True)
@@ -212,6 +214,7 @@ def run_(
     s3_bucket: typing.Optional[str] = None,
     s3_dir: typing.Optional[pathlib.Path] = None,
     with_bundle: typing.Optional[bool] = False,
+    with_parts: common.ComputeParts = common.DEFAULT_COMPUTE_PARTS,
 ) -> typing.Optional[pathlib.Path]:
     """Run an analysis."""
     # Make mypy happy.
@@ -285,7 +288,7 @@ def run_(
     country = utils.normalize_country_name(country)
     import_jobs = utils.is_usa(country)
 
-    compute.all(
+    compute.parts(
         database_url=database_url,
         sql_script_dir=sql_script_dir,
         output_srid=output_srid,
@@ -294,6 +297,7 @@ def run_(
         city_default_speed=city_default_speed,
         import_jobs=import_jobs,
         max_trip_distance=max_trip_distance,
+        compute_parts=with_parts,
     )
 
     # Export.

--- a/brokenspoke_analyzer/core/constant.py
+++ b/brokenspoke_analyzer/core/constant.py
@@ -1,4 +1,17 @@
 """Define the general constants."""
 
+from enum import Enum
+
 APPNAME = "brokenspoke-analyzer"
 APPAUTHOR = "PeopleForBikes"
+
+
+class ComputePart(str, Enum):
+    """Define the possible items to compute."""
+
+    FEATURES = "features"
+    STRESS = "stress"
+    CONNECTIVITY = "connectivity"
+
+
+COMPUTE_PARTS_ALL = list(ComputePart)

--- a/brokenspoke_analyzer/core/database/dbcore.py
+++ b/brokenspoke_analyzer/core/database/dbcore.py
@@ -4,6 +4,7 @@ import pathlib
 import typing
 
 from sqlalchemy import (
+    CursorResult,
     create_engine,
     text,
 )
@@ -170,3 +171,17 @@ def configure_schemas(engine: Engine, pguser: str) -> None:
         ),
     ]
     execute_with_autocommit(engine, statements)
+
+
+# (TODO)rgreinho: Check the schema of the tables. Maybe schema should be a parameter.
+def table_exists(engine: Engine, table: str) -> bool:
+    """Check whether a table exists or not."""
+    query = f"""SELECT EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_schema = 'public'  -- or your specific schema
+        AND table_name = '{table}'
+        );
+    """
+    with engine.connect() as conn:
+        res = conn.execute(text(query))
+        return bool(res.scalar_one())

--- a/brokenspoke_analyzer/core/exporter.py
+++ b/brokenspoke_analyzer/core/exporter.py
@@ -61,6 +61,9 @@ def export_to_csv(
 ) -> None:
     """Export a list of PostgreSQL tables to CSV files."""
     for table in tables:
+        # Skip export if the table does not exist.
+        if not dbcore.table_exists(engine, table):
+            continue
         csv_file = export_dir / f"{table}.csv"
         dbcore.export_to_csv(engine, csv_file, table)
 
@@ -69,7 +72,11 @@ def export_to_geojson(
     export_dir: pathlib.Path, tables: typing.Sequence[str], database_url: str
 ) -> None:
     """Export a list of PostGIS tables to GeoJSON files."""
+    engine = dbcore.create_psycopg_engine(database_url)
     for table in tables:
+        # Skip export if the table does not exist.
+        if not dbcore.table_exists(engine, table):
+            continue
         geojson_file = export_dir / f"{table}.geojson"
         runner.run_ogr2ogr_geojson_export(database_url, geojson_file, table)
 
@@ -78,7 +85,11 @@ def export_to_shp(
     export_dir: pathlib.Path, tables: typing.Sequence[str], database_url: str
 ) -> None:
     """Export a list of PostGIS tables to Shapefiles."""
+    engine = dbcore.create_psycopg_engine(database_url)
     for table in tables:
+        # Skip export if the table does not exist.
+        if not dbcore.table_exists(engine, table):
+            continue
         shapefile = export_dir / f"{table}.shp"
         runner.run_pgsql2shp(database_url, shapefile, table)
 

--- a/brokenspoke_analyzer/core/ingestor.py
+++ b/brokenspoke_analyzer/core/ingestor.py
@@ -13,7 +13,6 @@ from sqlalchemy.engine import Engine
 from brokenspoke_analyzer.cli import common
 from brokenspoke_analyzer.core import (
     analysis,
-    constant,
     runner,
     utils,
 )

--- a/docs/source/commands.md
+++ b/docs/source/commands.md
@@ -165,7 +165,29 @@ also required and must be specified with the `--input-dir` option flag.
 bna compute usa "santa rosa" "new mexico" --input-dir data/santa-rosa-new-mexico-usa
 ```
 
-All the results will be stored in various table in the database.
+Several parts are available for computing:
+
+- features
+- stress
+- connectivity.
+
+It is possible to use only some parts for the analysis. In this case, the
+`--with-parts` option can be used to specify which part to compute.
+
+```bash
+bna compute --with-parts stress usa "santa rosa" "new mexico" --input-dir data/santa-rosa-new-mexico-usa
+```
+
+You can also specify multiple parts by repeating the `--with-parts` option:
+
+```bash
+bna compute --with-parts stress --with-parts connectivity usa "santa rosa" "new mexico"
+--input-dir data/santa-rosa-new-mexico-usa
+```
+
+If the `--with-parts` option is not specified, all the parts will be computed.
+
+All the results will be stored in various tables in the database.
 
 ## Export
 
@@ -307,6 +329,9 @@ It still requires a configured, up and running database in order to complete.
 bna run usa "santa rosa" "new mexico" 3570670
 ```
 
+Like the for the [compute](#compute) command, the parts to be analyzed may be
+specified individually with the `--with-parts` argument.
+
 ## Run-with
 
 This command provides alternative ways to run the analysis.
@@ -331,6 +356,9 @@ Usage: bna run-with compose [OPTIONS] COUNTRY CITY [STATE] [FIPS_CODE]
 It combines the `configure`, `prepare`, `import`, `compute`, `export`
 sub-commands and wraps them into the setup and tear-down of the Docker Compose
 environment.
+
+Like the for the [compute](#compute) command, the parts to be analyzed may be
+specified individually with the `--with-parts` argument.
 
 ### Original-BNA
 

--- a/tests/test_brokenspoke_analyzer.py
+++ b/tests/test_brokenspoke_analyzer.py
@@ -1,11 +1,13 @@
 """Test module."""
 
+import os
 import pathlib
 
 import pytest
 from loguru import logger
 
 from brokenspoke_analyzer.core import datastore
+from brokenspoke_analyzer.core.database import dbcore
 from brokenspoke_analyzer.pyrosm import data
 
 logger.enable("brokenspoke_analyzer")
@@ -48,3 +50,9 @@ def test_truthy():
 #     await bna_store.download_census_waterblocks()
 #     await bna_store.download_lodes_data("ma", 2019)
 #     await bna_store.download_2010_census_blocks("25")
+
+# def test_table_exists():
+#     """Checks whether a table exists or not."""
+#     engine = dbcore.create_psycopg_engine(os.getenv("DATABASE_URL"))
+#     res = dbcore.table_exists(engine=engine, table="neighborhood_colleges")
+#     assert res == True


### PR DESCRIPTION
Adds the ability to select wich parts of the analysis to run (e.g.
features, stress or connectivity).

The compute logic was updated to account for the dependencies between
the different parts. For instance, the "stress" part requires the
"features" part to run. This determination is made automatically for the
user.

The export logic was also updated to prevent non-existing tables to be
exporting, which would result in a crash. Indeed, if not all the parts
were run, not all the tables were created.

The documentation was updated accordingly.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>