### PR TITLE
Normalize country name before building location slug in compute command

### DIFF
--- a/brokenspoke_analyzer/cli/root.py
+++ b/brokenspoke_analyzer/cli/root.py
@@ -124,6 +124,7 @@ def compute_cmd(
     engine = dbcore.create_psycopg_engine(database_url)
 
     # Prepare directories.
+    country = utils.normalize_country_name(country)
     _, slug = analysis.osmnx_query(country, city, region)
     traversable = resources.files("brokenspoke_analyzer.scripts.sql")
     res = pathlib.Path(traversable._paths[0])  # type: ignore
@@ -134,7 +135,6 @@ def compute_cmd(
     state_default_speed, city_default_speed = ingestor.retrieve_default_speed_limits(
         engine
     )
-    country = utils.normalize_country_name(country)
     import_jobs = utils.is_usa(country)
 
     # Compute the output SRID from the boundary file.


### PR DESCRIPTION
# Pull-Request

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to
  change)
- Code cleanup / Refactoring
- Documentation
- Infrastructure and automation

## Description

I'll often run commands individually, `bna import all`, `bna compute`, etc. I recently ran into an issue with compute sometimes not finding the right boundary file when running something like `bna compute us monona wisconsin` because it would be looking for `monona-wisconsin-us.shp` and not find it because the `prepare` command uses the normalized version of country (and saved it as `monona-wisconsin-united-states.shp`). It seems like the boundary file should always use the normalized version of the country based on other call [here](https://github.com/peopleforbikes/brokenspoke-analyzer/blob/8ccec40fe20f738961a90675ffa531d8558e8250/brokenspoke_analyzer/cli/prepare.py#L60) at the beginning of the `prepare` command.

This PR moves the country normalization call above the building of the slug used to find the boundary file path, similar to what is done [here](https://github.com/peopleforbikes/brokenspoke-analyzer/blob/8ccec40fe20f738961a90675ffa531d8558e8250/brokenspoke_analyzer/core/ingestor.py#L525-L535).


## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the Changelog (if applicable)

<!--
Place the URL of the issue here if this PR fixes an existing issue.
Use either the `username/repository#` syntax (preferred) or the *FULL* URL.
-->

Fixes: PeopleForBikes/PeopleForBikes.github.io#
