### PR TITLE
Fix measure

### DIFF
--- a/brokenspoke_analyzer/cli/root.py
+++ b/brokenspoke_analyzer/cli/root.py
@@ -151,6 +151,7 @@ def compute_cmd(
             state_default_speed=state_default_speed,
             city_default_speed=city_default_speed,
             import_jobs=import_jobs,
+            compute_parts=with_parts,
         )
         console.log(f"Analysis for {slug} complete.")
 


### PR DESCRIPTION
Closes #858 

Before, mileage was calculated and reported in a directional way, so there was a mileage for each of `ft_` and `tf_`. This PR changes the `measure` calculation so that mileage is added up for both directions. A LATERAL join is used to avoid scanning the same table twice.
