### PR TITLE
Add off-street paths to measure

### DIFF
--- a/brokenspoke_analyzer/scripts/sql/features/calculate_mileage.sql
+++ b/brokenspoke_analyzer/scripts/sql/features/calculate_mileage.sql
@@ -22,8 +22,21 @@ FROM (
         LATERAL (
             VALUES
             (neighborhood_ways.ft_bike_infra),
-            (neighborhood_ways.tf_bike_infra)
+            (neighborhood_ways.tf_bike_infra),
+            (
+                CASE
+                    WHEN
+                        (
+                            neighborhood_ways.functional_class = 'path'
+                            AND neighborhood_ways.xwalk IS NULL
+                        )
+                        THEN 'path'
+                END
+            )
         ) AS features (feature_type)
-    WHERE features.feature_type IN ('sharrow', 'buffered_lane', 'lane', 'track')
+    WHERE
+        features.feature_type IN (
+            'sharrow', 'buffered_lane', 'lane', 'track', 'path'
+        )
 ) AS all_features
 GROUP BY all_features.feature_type;


### PR DESCRIPTION
Fixes #869 

Adds off-street paths mileage calculation to `measure`. Off-street paths are defined to match the BNA's legend definition:

<img src="https://github.com/user-attachments/assets/88c9f114-78c4-4ac4-87ec-bb7c9b2f57d1" width="170">
