### PR TITLE
Fix Rich live error when displaying spinner

### DIFF
--- a/brokenspoke_analyzer/cli/run_with.py
+++ b/brokenspoke_analyzer/cli/run_with.py
@@ -319,30 +319,29 @@ def run_(
 
     # Export.
     console.log("[green]Exporting the results...")
-    with console.status("Exporting..."):
-        if with_export == exporter.Exporter.none:
-            return None
-        elif with_export == exporter.Exporter.local:
-            export_dir = export.local(
-                database_url=database_url,
-                country=country,
-                city=city,
-                region=region,
-                export_dir=export_dir,
-                with_bundle=with_bundle,
-            )
-        elif with_export == exporter.Exporter.s3:
-            export_dir = export.s3(
-                database_url=database_url,
-                bucket_name=s3_bucket,  # type: ignore
-                country=country,
-                city=city,
-                region=region,
-            )
-        elif with_export == exporter.Exporter.s3_custom:
-            export_dir = export.s3_custom(
-                database_url=database_url,
-                bucket_name=s3_bucket,  # type: ignore
-                s3_dir=s3_dir,
-            )
+    if with_export == exporter.Exporter.none:
+        return None
+    elif with_export == exporter.Exporter.local:
+        export_dir = export.local(
+            database_url=database_url,
+            country=country,
+            city=city,
+            region=region,
+            export_dir=export_dir,
+            with_bundle=with_bundle,
+        )
+    elif with_export == exporter.Exporter.s3:
+        export_dir = export.s3(
+            database_url=database_url,
+            bucket_name=s3_bucket,  # type: ignore
+            country=country,
+            city=city,
+            region=region,
+        )
+    elif with_export == exporter.Exporter.s3_custom:
+        export_dir = export.s3_custom(
+            database_url=database_url,
+            bucket_name=s3_bucket,  # type: ignore
+            s3_dir=s3_dir,
+        )
     return export_dir


### PR DESCRIPTION
Prevents the use of nested spinners when exporting the results. It
turned out that in some cases this behavior causes Rich to crash
preventing the export to complete.

Fixes: PeopleForBikes/brokenspoke-analyzer#881

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
