### PR TITLE
Remove redundant LODES table updates

### DIFF
--- a/brokenspoke_analyzer/scripts/sql/connectivity/census_block_jobs.sql
+++ b/brokenspoke_analyzer/scripts/sql/connectivity/census_block_jobs.sql
@@ -11,12 +11,6 @@
 --     as per https://lehd.ces.census.gov/doc/help/onthemap/LODESTechDoc.pdf
 ----------------------------------------
 
--- process imported tables
-ALTER TABLE state_od_aux_jt00 ALTER COLUMN w_geocode TYPE VARCHAR(15);
-UPDATE state_od_aux_jt00 SET w_geocode = rpad(w_geocode, 15, '0'); --just in case we lost any trailing zeros
-ALTER TABLE state_od_main_jt00 ALTER COLUMN w_geocode TYPE VARCHAR(15);
-UPDATE state_od_main_jt00 SET w_geocode = rpad(w_geocode, 15, '0'); --just in case we lost any trailing zeros
-
 -- indexes
 CREATE INDEX IF NOT EXISTS tidx_auxjtw ON state_od_aux_jt00 (w_geocode);
 CREATE INDEX IF NOT EXISTS tidx_mainjtw ON state_od_main_jt00 (w_geocode);


### PR DESCRIPTION
# Pull-Request

## Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to
  change)
- Code cleanup / Refactoring
- Documentation
- Infrastructure and automation

## Description

The alteration of the column types and padding of the column values can be quite slow at around 6-10 seconds for Wisconsin (so there is maybe some overlap with #649) and seems to be redundant in my interaction with the LODES data. I'd expect it to be a pretty significant error if the source data had a census block identifier that was the incorrect length, and I'm not sure trying to pad the data would always result in the correct result. The inclusion of these updates seems to date pretty far back, and I couldn't find much beyond the SQL comment related to processing the imported data. Given that with the performance impact, I think removing the lines should be considered.

It might be better to add something like a check constraint on the length of the column if data validation is desired here, but there aren't any currently for other Census block columns so I wasn't sure.

<!--
Motivation and Context
Why is this change required? What problem does it solve?
-->

<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the Changelog (if applicable)
