### PR TITLE
Exclude golf course paths

### DIFF
--- a/brokenspoke_analyzer/scripts/pfb.style
+++ b/brokenspoke_analyzer/scripts/pfb.style
@@ -106,6 +106,8 @@ way        cycleway:both:width  text linear
 node,way   flashing_lights      text linear
 node,way   foot         text         linear
 way        footway      text         linear
+way        golf         text         linear
+way        golf_cart    text         linear
 node,way   healthcare   text         polygon
 node,way   highway      text         linear
 node,way   junction     text         linear

--- a/brokenspoke_analyzer/scripts/sql/features/functional_class.sql
+++ b/brokenspoke_analyzer/scripts/sql/features/functional_class.sql
@@ -116,6 +116,27 @@ WHERE
     );
 
 UPDATE neighborhood_ways
+SET functional_class = 'unclassified'
+FROM neighborhood_osm_full_line AS osm
+WHERE
+    neighborhood_ways.osm_id = osm.osm_id
+    AND osm.highway = 'path'
+    AND (
+        osm.golf = 'path'
+        OR osm.golf = 'cartpath'
+        OR osm.golf_cart = 'yes'
+        OR osm.golf_cart = 'designated'
+    )
+    AND (
+        osm.access IS NULL
+        OR (
+            osm.access = 'no'
+            AND osm.bicycle IN ('yes', 'permissive', 'designated')
+        )
+        OR osm.access NOT IN ('no', 'private')
+    );
+
+UPDATE neighborhood_ways
 SET functional_class = 'living_street'
 FROM neighborhood_osm_full_line AS osm
 WHERE


### PR DESCRIPTION
Golf course paths will still show up as low stress roads, but not as paths since this wasn't infrastructure that was built
for exclusive biking/pedestrian use.

Fixes #887 
