### PR TITLE
Fix conversion of zero to NULL in SQL query substitution

### DIFF
--- a/brokenspoke_analyzer/core/compute.py
+++ b/brokenspoke_analyzer/core/compute.py
@@ -33,7 +33,7 @@ def execute_sqlfile_with_substitutions(
         binding_names = sorted(bind_params.keys(), key=len, reverse=True)
         for binding_name in binding_names:
             param = bind_params[binding_name]
-            substitute = param if param else "NULL"
+            substitute = param if param != None else "NULL"
             statements = statements.replace(f":{binding_name}", f"{substitute}")
     dbcore.execute_query(engine, statements)
 


### PR DESCRIPTION
# Pull-Request

## Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to
  change)
- Code cleanup / Refactoring
- Documentation
- Infrastructure and automation

## Description

I noticed some odd results in calculating [access scores](https://github.com/peopleforbikes/brokenspoke-analyzer/blob/8d9bfdea7ea9ab2d64b501ca1b1aaf5017da2e04/brokenspoke_analyzer/core/compute.py#L414-L426) when the second or third score was 0 (currently colleges, hospitals, social_services, transit, and supermarkets). The result is even when there are non-zero `social_services_low_stress` / `social_services_high_stress` in the `neighborhood_census_blocks` table, the `social_services_score` would be NULL, which doesn't seem intended.

If I print out the SQL generated for social_services, the problem seemed to be due to the zeros being converted to NULL:

<details>
<summary>
I've put the complete file below in the details section, but the most relevant part is here:

```sql
    WHEN NULL = 0
        THEN
            0.7
            + ((1 - 0.7) * (social_services_low_stress::FLOAT - 1))
            / (social_services_high_stress - 1)
    WHEN NULL = 0
        THEN CASE
            WHEN social_services_low_stress = 1 THEN 0.7
            WHEN social_services_low_stress = 2 THEN 0.7 + NULL
            ELSE
                0.7 + NULL
                + (
                    (1 - 0.7 - NULL)
                    * (social_services_low_stress::FLOAT - 2)
                )
                / (social_services_high_stress - 2)
        END
```

</summary>

```sql
----------------------------------------
-- Input variables:
--      1 - Maximum score value
--      0.7 - Value of first available destination (if 0 then ignore--a basic ratio is used for the score)
--      NULL - Value of second available destination (if 0 then ignore--a basic ratio is used after 1)
--      NULL - Value of third available destination (if 0 then ignore--a basic ratio is used after 2)
----------------------------------------
-- set block-based raw numbers
UPDATE neighborhood_census_blocks
SET
    social_services_low_stress = (
        SELECT COUNT(id)
        FROM neighborhood_social_services
        WHERE EXISTS (
            SELECT 1
            FROM neighborhood_connected_census_blocks
            WHERE
                neighborhood_connected_census_blocks.source_blockid20
                = neighborhood_census_blocks.geoid20
                AND neighborhood_connected_census_blocks.target_blockid20
                = ANY(neighborhood_social_services.blockid20)
                AND neighborhood_connected_census_blocks.low_stress
        )
    ),
    social_services_high_stress = (
        SELECT COUNT(id)
        FROM neighborhood_social_services
        WHERE EXISTS (
            SELECT 1
            FROM neighborhood_connected_census_blocks
            WHERE
                neighborhood_connected_census_blocks.source_blockid20
                = neighborhood_census_blocks.geoid20
                AND neighborhood_connected_census_blocks.target_blockid20
                = ANY(neighborhood_social_services.blockid20)
        )
    )
WHERE EXISTS (
    SELECT 1
    FROM neighborhood_boundary AS b
    WHERE ST_Intersects(neighborhood_census_blocks.geom, b.geom)
);

-- set block-based score
UPDATE neighborhood_census_blocks
SET social_services_score = CASE
    WHEN social_services_high_stress IS NULL THEN NULL
    WHEN social_services_high_stress = 0 THEN NULL
    WHEN social_services_low_stress = 0 THEN 0
    WHEN
        social_services_high_stress = social_services_low_stress
        THEN 1
    WHEN
        0.7 = 0
        THEN social_services_low_stress::FLOAT / social_services_high_stress
    WHEN NULL = 0
        THEN
            0.7
            + ((1 - 0.7) * (social_services_low_stress::FLOAT - 1))
            / (social_services_high_stress - 1)
    WHEN NULL = 0
        THEN CASE
            WHEN social_services_low_stress = 1 THEN 0.7
            WHEN social_services_low_stress = 2 THEN 0.7 + NULL
            ELSE
                0.7 + NULL
                + (
                    (1 - 0.7 - NULL)
                    * (social_services_low_stress::FLOAT - 2)
                )
                / (social_services_high_stress - 2)
        END
    ELSE CASE
        WHEN social_services_low_stress = 1 THEN 0.7
        WHEN social_services_low_stress = 2 THEN 0.7 + NULL
        WHEN social_services_low_stress = 3 THEN 0.7 + NULL + NULL
        ELSE
            0.7 + NULL + NULL
            + (
                (1 - 0.7 - NULL - NULL)
                * (social_services_low_stress::FLOAT - 3)
            )
            / (social_services_high_stress - 3)
    END
END;

-- set population shed for each social service destination in the neighborhood
UPDATE neighborhood_social_services
SET
    pop_high_stress = (
        SELECT SUM(shed.pop)
        FROM (
            SELECT
                cb.geoid20,
                MAX(cb.pop20) AS pop
            FROM neighborhood_census_blocks AS cb,
                neighborhood_connected_census_blocks AS cbs
            WHERE
                cbs.source_blockid20 = cb.geoid20
                AND cbs.target_blockid20
                = ANY(neighborhood_social_services.blockid20)
            GROUP BY cb.geoid20
        ) AS shed
    ),
    pop_low_stress = (
        SELECT SUM(shed.pop)
        FROM (
            SELECT
                cb.geoid20,
                MAX(cb.pop20) AS pop
            FROM neighborhood_census_blocks AS cb,
                neighborhood_connected_census_blocks AS cbs
            WHERE
                cbs.source_blockid20 = cb.geoid20
                AND cbs.target_blockid20
                = ANY(neighborhood_social_services.blockid20)
                AND cbs.low_stress
            GROUP BY cb.geoid20
        ) AS shed
    )
WHERE EXISTS (
    SELECT 1
    FROM neighborhood_boundary AS b
    WHERE ST_Intersects(neighborhood_social_services.geom_pt, b.geom)
);

UPDATE neighborhood_social_services
SET pop_score = CASE
    WHEN pop_high_stress IS NULL THEN NULL
    WHEN pop_high_stress = 0 THEN 0
    ELSE pop_low_stress::FLOAT / pop_high_stress
END;
```

It appears to be due to Python evaluating `0` as `False` in conditionals, which results in the NULL substitution in the line I've proposed changing. To address it, I've changed the conditional to check if the value is `None`. I couldn't find any places where the substitution was using a `None` value, so I think this is a safe change to fix the issue.

I did run some test cities, and I see the correctly calculated `social_services_score`, etc. scores in `neighborhood_census_blocks` now.

</details>

<!--
Motivation and Context
Why is this change required? What problem does it solve?
-->

<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

- [] I have updated the documentation accordingly
- [] I have updated the Changelog (if applicable)

<!--
Place the URL of the issue here if this PR fixes an existing issue.
Use either the `username/repository#` syntax (preferred) or the *FULL* URL.
-->

Fixes: PeopleForBikes/PeopleForBikes.github.io#
