### PR TITLE
Support new pedestrian island tagging when setting island column

### DIFF
--- a/brokenspoke_analyzer/scripts/sql/features/island.sql
+++ b/brokenspoke_analyzer/scripts/sql/features/island.sql
@@ -6,6 +6,7 @@
 ----------------------------------------
 UPDATE neighborhood_ways_intersections SET island = FALSE;
 
+-- noqa: disable=RF05
 UPDATE neighborhood_ways_intersections
 SET island = TRUE
 WHERE
@@ -15,10 +16,11 @@ WHERE
         FROM neighborhood_osm_full_point AS osm
         WHERE
             osm.highway = 'crossing'
-            AND osm.crossing = 'island'
+            AND (osm.crossing = 'island' OR osm."crossing:island" = 'yes')
             AND ST_DWithin(
                 neighborhood_ways_intersections.geom,
                 osm.way,
                 :sigctl_search_dist
             )
     );
+-- noqa: enable=all


### PR DESCRIPTION
# Pull-Request

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to
  change)
- Code cleanup / Refactoring
- Documentation
- Infrastructure and automation

## Description

This PR proposes adding support for the `crossing:island` tag as it now supersedes `crossing=island` (per [OSM Wiki](https://wiki.openstreetmap.org/w/index.php?title=Proposed_features/Key:crossing:island&oldid=1780913)).

<!--
Describe your changes in detail.
Add a screenshot if applicable.
-->

<!--
Motivation and Context
Why is this change required? What problem does it solve?
-->

<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the Changelog (if applicable)

<!--
Place the URL of the issue here if this PR fixes an existing issue.
Use either the `username/repository#` syntax (preferred) or the *FULL* URL.
-->
