### PR TITLE
Fix postgres healthcheck command

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -11,7 +11,7 @@ services:
       POSTGRESQL_PASSWORD: bna
       POSTGRESQL_DATABASE: bna
     healthcheck:
-      test: ["CMD", "pg_isready"]
+      test: ["CMD", "pg_isready", "-d", "postgres", "-U", "postgres"]
       interval: 10s
       timeout: 60s
       retries: 6


### PR DESCRIPTION
When running the healthcheck command, postgres was trying to connect
using the system user, which in a container shell is root,
so we were seeing the message "FATAL:  role "root" does not exist".
Adding a user to the command fixes this issue.

Fixes: PeopleForBikes/brokenspoke-analyzer#898
