### PR TITLE
Remove Country Georgia from Geofabrik

### DIFF
--- a/brokenspoke_analyzer/pyrosm/data/geofabrik.py
+++ b/brokenspoke_analyzer/pyrosm/data/geofabrik.py
@@ -958,7 +958,6 @@ class Europe:
         "faroe_islands",
         "finland",
         "france",
-        "georgia",
         "germany",
         "great_britain",
         "greece",


### PR DESCRIPTION
In the GeoFabrik client, the country Georgia and the US Georgia have
identical names, therefore the US state is never found because it
appears later in the list (Europe/Georgia vs NorthAmerica/Georgia).

Since we do not analyze cities in the country Georgia, we can simply
remove it.

For reference this issue was reported upstream in Dec 2021:
https://github.com/pyrosm/pyrosm/issues/162

Fixes PeopleForBikes/brokenspoke-analyzer#938

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
