### PR TITLE
Prevent Pygris to output messages

### DIFF
--- a/brokenspoke_analyzer/cli/common.py
+++ b/brokenspoke_analyzer/cli/common.py
@@ -12,16 +12,17 @@ from brokenspoke_analyzer.core import constant
 DEFAULT_BLOCK_POPULATION = 100
 DEFAULT_BLOCK_SIZE = 500
 DEFAULT_BUFFER = 2680
-DEFAULT_LODES_YEAR = 2022
 DEFAULT_CITY_FIPS_CODE = "0"  # "0" means an non-US city.
 DEFAULT_CITY_SPEED_LIMIT = 30
-DEFAULT_CONTAINER_NAME = "brokenspoke-analyzer"
-DEFAULT_DOCKER_IMAGE = "azavea/pfb-network-connectivity:0.19.0"
-DEFAULT_DATA_DIR = pathlib.Path("./data").resolve()
-DEFAULT_EXPORT_DIR = pathlib.Path("./results").resolve()
-DEFAULT_RETRIES = 2
-DEFAULT_MAX_TRIP_DISTANCE = 2680
 DEFAULT_COMPUTE_PARTS = constant.COMPUTE_PARTS_ALL
+DEFAULT_CONTAINER_NAME = "brokenspoke-analyzer"
+DEFAULT_DATA_DIR = pathlib.Path("./data").resolve()
+DEFAULT_DOCKER_IMAGE = "azavea/pfb-network-connectivity:0.19.0"
+DEFAULT_EXPORT_DIR = pathlib.Path("./results").resolve()
+DEFAULT_LODES_YEAR = 2022
+DEFAULT_MAX_TRIP_DISTANCE = 2680
+DEFAULT_PYGRIS_YEAR = 2024
+DEFAULT_RETRIES = 2
 
 # Default Typer Arguments/Options.
 BlockPopulation = Annotated[

--- a/brokenspoke_analyzer/core/analysis.py
+++ b/brokenspoke_analyzer/core/analysis.py
@@ -162,7 +162,9 @@ def retrieve_city_boundaries(
     # with OSM as a fallback for other places.
     if fips_code is not None and fips_code != common.DEFAULT_CITY_FIPS_CODE:
         cache_enabled = os.getenv("BNA_PYGRIS_CACHE", "1") == "1"
-        places = pygris.places(state=fips_code[:2], cache=cache_enabled)
+        places = pygris.places(
+            state=fips_code[:2], cache=cache_enabled, year=common.DEFAULT_PYGRIS_YEAR
+        )
         city_gdf = places[places["PLACEFP"] == fips_code[2:]]
     else:
         settings.use_cache = os.getenv("BNA_OSMNX_CACHE", "1") == "1"


### PR DESCRIPTION
By default Pygris displays messages on the console. By specifying a
default year to its functions, it hides these messages, keeping our
output nice an consistent.

Fixes PeopleForBikes/brokenspoke-analyzer#979

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
