### PR TITLE
Fix two-way cycle tracks stress designation

### DIFF
--- a/brokenspoke_analyzer/scripts/sql/features/bike_infra.sql
+++ b/brokenspoke_analyzer/scripts/sql/features/bike_infra.sql
@@ -32,20 +32,18 @@ SET
         WHEN
             (
                 osm."cycleway:right" = 'track'
-                AND osm."oneway:bicycle" = 'no'
                 AND (
-                    osm."cycleway:right:oneway" != '-1'
-                    OR osm."cycleway:right:oneway" IS NULL
+                    osm."oneway:bicycle" = 'no'
+                    OR osm."cycleway:right:oneway" = 'no'
                 )
             )
             THEN 'track'
         WHEN
             (
                 osm."cycleway:left" = 'track'
-                AND osm."oneway:bicycle" = 'no'
                 AND (
-                    osm."cycleway:left:oneway" != '-1'
-                    OR osm."cycleway:left:oneway" IS NULL
+                    osm."oneway:bicycle" = 'no'
+                    OR osm."cycleway:left:oneway" = 'no'
                 )
             )
             THEN 'track'
@@ -281,20 +279,18 @@ SET
         WHEN
             (
                 osm."cycleway:right" = 'track'
-                AND osm."oneway:bicycle" = 'no'
                 AND (
-                    osm."cycleway:right:oneway" != '-1'
-                    OR osm."cycleway:right:oneway" IS NULL
+                    osm."oneway:bicycle" = 'no'
+                    OR osm."cycleway:right:oneway" = 'no'
                 )
             )
             THEN 'track'
         WHEN
             (
                 osm."cycleway:left" = 'track'
-                AND osm."oneway:bicycle" = 'no'
                 AND (
-                    osm."cycleway:left:oneway" != '-1'
-                    OR osm."cycleway:left:oneway" IS NULL
+                    osm."oneway:bicycle" = 'no'
+                    OR osm."cycleway:left:oneway" = 'no'
                 )
             )
             THEN 'track'


### PR DESCRIPTION
# Pull-Request

## Types of changes

<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to
  change)
- Code cleanup / Refactoring
- Documentation
- Infrastructure and automation

## Description

There is a bug in the changes from https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/890 that results in two-way cycle tracks in being classified as high stress in the "both ways" cases.

An example is way [1199660627] (https://www.openstreetmap.org/way/1199660627#map=20/43.0507475/-87.9033802&layers=C), which is currently designated as high stress but has a two-way cycle track. Tagging that implies two-way `cycleway:left/right:oneway` with an associated `cycleway:left/right=track` should always result in a low-stress designation, but the query as-is does not catch them.

To fix it, I'm proposing setting the infra to `track` if one side is tagged as track, and there are tags indicating the cycleway is two-way.

<!--
Motivation and Context
Why is this change required? What problem does it solve?
-->

<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the Changelog (if applicable)

<!--
Place the URL of the issue here if this PR fixes an existing issue.
Use either the `username/repository#` syntax (preferred) or the *FULL* URL.
-->

Fixes: PeopleForBikes/PeopleForBikes.github.io#
