### PR TITLE
Remove routable unpaved ways

### DIFF
--- a/brokenspoke_analyzer/core/compute.py
+++ b/brokenspoke_analyzer/core/compute.py
@@ -74,6 +74,32 @@ def features(
         sql_script = sql_feature_script_dir / script
         dbcore.execute_sql_file(engine, sql_script)
     sql_script = sql_feature_script_dir / "paths.sql"
+
+    logger.info("Remove routable unpaved ways")
+    dbcore.execute_query(
+        engine,
+        """
+        DELETE FROM neighborhood_ways w
+        USING neighborhood_osm_full_line o
+        WHERE
+            w.osm_id = o.osm_id AND surface IN (
+                'dirt',
+                'unpaved',
+                'sand',
+                'compacted',
+                'ground',
+                'rock',
+                'soil',
+                'earth',
+                'gravel',
+                'woodchips',
+                'fine_gravel',
+                'mud',
+                'grass'
+            );
+        """,
+    )
+
     bind_params = {"nb_output_srid": output_srid}
     execute_sqlfile_with_substitutions(engine, sql_script, bind_params)
     sql_scripts = [


### PR DESCRIPTION
# Pull-Request

## Types of changes

<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to
  change)
- Code cleanup / Refactoring
- Documentation
- Infrastructure and automation

## Description

Currently all ways are included, regardless of surface type. In limited investigation, most often these are paths, though the potential to include unpaved roads is also present.

I wasn't sure on the desired impact on `neighborhood_paths` destinations, so the proposed changes here only deletes `neighborhood_ways` used to route. This means that unpaved paths will still be included as potential path/trail destinations.

In choosing which values to exclude, I used [taginfo](https://taginfo.openstreetmap.org/keys/surface#values) to choose the most common values that are not paved.

<!--
Motivation and Context
Why is this change required? What problem does it solve?
-->

<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the Changelog (if applicable)

<!--
Place the URL of the issue here if this PR fixes an existing issue.
Use either the `username/repository#` syntax (preferred) or the *FULL* URL.
-->

Fixes: PeopleForBikes/PeopleForBikes.github.io#
