### PR TITLE
Remove duplicate neighborhood_ways_net_vert road_id index

### DIFF
--- a/brokenspoke_analyzer/scripts/sql/connectivity/build_network.sql
+++ b/brokenspoke_analyzer/scripts/sql/connectivity/build_network.sql
@@ -267,10 +267,6 @@ WHERE
     AND roads1.road_id != roads2.road_id;
 
 -- index
-CREATE INDEX idx_neighborhood_ways_net_vert_road_id
-ON received.neighborhood_ways_net_vert (
-    road_id
-);
 CREATE INDEX idx_neighborhood_ways_net_link_int_id
 ON received.neighborhood_ways_net_link (
     int_id


### PR DESCRIPTION
# Pull-Request

## Types of changes

<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to
  change)
- Code cleanup / Refactoring
- Documentation
- Infrastructure and automation

## Description

Noticed recently there's a duplicate index in this file. An identical index is created earlier [here](https://github.com/peopleforbikes/brokenspoke-analyzer/blob/e717818ee37f0da6f9a5605e68978e26c372db10/brokenspoke_analyzer/scripts/sql/connectivity/build_network.sql#L53-L56). I think this is the right one to remove because the remaining one is added after the bulk insert on the table, but before the queries that would use the index when inserting into `neighborhood_ways_net_link`.

<!--
Motivation and Context
Why is this change required? What problem does it solve?
-->

<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the Changelog (if applicable)

<!--
Place the URL of the issue here if this PR fixes an existing issue.
Use either the `username/repository#` syntax (preferred) or the *FULL* URL.
-->

Fixes: PeopleForBikes/PeopleForBikes.github.io#
