### PR TITLE
Update stress_segments_higher_order.sql

### DIFF
--- a/brokenspoke_analyzer/scripts/sql/stress/stress_segments_higher_order.sql
+++ b/brokenspoke_analyzer/scripts/sql/stress/stress_segments_higher_order.sql
@@ -59,9 +59,9 @@ SET
                     THEN CASE
                         -- speed limit > 25
                         WHEN
-                            COALESCE(speed_limit, :default_speed) > 25
+                            COALESCE(speed_limit, :default_speed) > 20
                             THEN 3
-                        WHEN COALESCE(speed_limit, :default_speed) <= 25
+                        WHEN COALESCE(speed_limit, :default_speed) <= 20
                             THEN CASE
                                 WHEN
                                     COALESCE(ft_lanes, :default_lanes) > 1
@@ -114,7 +114,7 @@ SET
                 ELSE 3
             END
 
-        WHEN tf_bike_infra = 'lane' AND COALESCE(ft_park, :default_parking) = 1
+        WHEN tf_bike_infra = 'lane' AND COALESCE(tf_park, :default_parking) = 1
             THEN CASE
                 -- treat as conventional lane
                 WHEN
@@ -123,9 +123,9 @@ SET
                     THEN CASE
                         -- speed limit > 25
                         WHEN
-                            COALESCE(speed_limit, :default_speed) > 25
+                            COALESCE(speed_limit, :default_speed) > 20
                             THEN 3
-                        WHEN COALESCE(speed_limit, :default_speed) <= 25
+                        WHEN COALESCE(speed_limit, :default_speed) <= 20
                             THEN CASE
                                 WHEN
                                     COALESCE(tf_lanes, :default_lanes) > 1


### PR DESCRIPTION
Fix speed limit cutoffs and typo for higher order segments to match NACTO standards

# Pull-Request

## Types of changes

<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->

- [x] - Bug fix (non-breaking change which fixes an issue)
- [ ] - New feature (non-breaking change which adds functionality)
- [ ] - Breaking change (fix or feature that would cause existing functionality to change)
- [ ] - Code cleanup / Refactoring
- [ ] - Documentation
- [ ] - Infrastructure and automation

## Description

<!--
Describe your changes in detail.
Add a screenshot if applicable.
-->
The higher order stress segments previously treated bike lanes without parking >=12 feet as buffered lanes. These should instead be treated as conventional lanes, using a speed limit cutoff of 20 mph instead of 25 mph to follow NACTO guidelines.

<img width="824" height="314" alt="image" src="https://github.com/user-attachments/assets/5e6f2b51-904a-4953-a5a9-26f5fb1de85d" />


This update would be used instead of #1020 
## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

- [] I have updated the documentation accordingly
- [] I have updated the Changelog (if applicable)

<!--
Place the URL of the issue here if this PR fixes an existing issue.
Use either the `username/repository#` syntax (preferred) or the *FULL* URL.
-->

Fixes: PeopleForBikes/PeopleForBikes.github.io#
