### PR TITLE
Expand the exporter to support more object stores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,11 +25,10 @@ __pycache__/
 *.py[cod]
 *.so
 *.spec
-/data-*/
-/data/
 build/
 cache/
 coverage.xml
+data/
 deps
 develop-eggs/
 dist/

--- a/brokenspoke_analyzer/cli/export.py
+++ b/brokenspoke_analyzer/cli/export.py
@@ -1,18 +1,63 @@
 """Define the export sub-command."""
 
+import asyncio
 import pathlib
-import typing
 
 import rich
 import typer
+from click.core import ParameterSource
 from loguru import logger
+from obstore import store
 from typing_extensions import Annotated
 
 from brokenspoke_analyzer.cli import common
 from brokenspoke_analyzer.core import exporter
 
+# import typing
+
+
 app = typer.Typer()
 console = rich.get_console()
+
+
+def allow_only_env_var(
+    ctx: typer.Context, param: typer.CallbackParam, value: str
+) -> str:
+    """Allow only environment variables for a parameter."""
+    if param.name is None:
+        raise ValueError(f"{param.name} must be set.")
+    if ctx.get_parameter_source(param.name) != ParameterSource.ENVIRONMENT:
+        raise typer.BadParameter("only allowed as environment variable")
+    return value
+
+
+CloudflareAccountID = Annotated[
+    str,
+    typer.Option(
+        help="Cloudflare Account ID",
+        envvar="CLOUDFLARE_ACCOUNT_ID",
+        callback=allow_only_env_var,
+    ),
+]
+R2AccessKeyID = Annotated[
+    str,
+    typer.Option(
+        help="R2 Access Key ID",
+        envvar="R2_ACCESS_KEY_ID",
+        callback=allow_only_env_var,
+    ),
+]
+R2SecretAccessKey = Annotated[
+    str,
+    typer.Option(
+        help="R2 Secret Access Key",
+        envvar="R2_SECRET_ACCESS_KEY",
+        callback=allow_only_env_var,
+    ),
+]
+WithBundle = Annotated[
+    bool, typer.Argument(help="bundle all the files in a zip archive")
+]
 
 
 @app.command()
@@ -54,25 +99,67 @@ def s3(
 ) -> pathlib.Path:
     """Export results to a S3 bucket following the PFB calver convention."""
     with console.status("[green]Uploading results to AWS S3..."):
-        folder = exporter.create_calver_s3_directories(
-            bucket_name, country, city, region
+        return asyncio.run(
+            s3_(database_url, bucket_name, country, city, region, with_bundle)
         )
-        exporter.s3(database_url, bucket_name, folder, with_bundle)
-        return folder
 
 
 @app.command()
 def s3_custom(
     database_url: common.DatabaseURL,
     bucket_name: str,
-    s3_dir: typing.Optional[pathlib.Path] = pathlib.Path(),
+    s3_dir: pathlib.Path = pathlib.Path(),
     with_bundle: common.WithBundle = False,
 ) -> pathlib.Path:
     """Export results to a custom S3 bucket."""
     with console.status("[green]Uploading results to AWS S3..."):
-        folder = exporter.s3_directories(bucket_name, s3_dir)
-        exporter.s3(database_url, bucket_name, folder, with_bundle)
-        return folder
+        return asyncio.run(s3_custom_(database_url, bucket_name, s3_dir, with_bundle))
+
+
+@app.command()
+def r2(
+    database_url: common.DatabaseURL,
+    account_id: CloudflareAccountID,
+    access_key_id: R2AccessKeyID,
+    secret_access_key: R2SecretAccessKey,
+    bucket_name: str,
+    country: common.Country,
+    city: common.City,
+    region: common.Region = None,
+    with_bundle: bool = False,
+) -> None:
+    """
+    Export results to a R2 bucket following the PFB calver convention.
+
+    Authentication is done via environment variables:
+    - CLOUDFLARE_ACCOUNT_ID
+    - R2_ACCESS_KEY_ID
+    - R2_SECRET_ACCESS_KEY
+    """
+    with console.status("[green]Uploading results to Cloudflare R2..."):
+        asyncio.run(r2_(database_url, bucket_name, country, city, region, with_bundle))
+
+
+@app.command()
+def r2_custom(
+    database_url: common.DatabaseURL,
+    account_id: CloudflareAccountID,
+    access_key_id: R2AccessKeyID,
+    secret_access_key: R2SecretAccessKey,
+    bucket_name: str,
+    s3_dir: pathlib.Path = pathlib.Path(),
+    with_bundle: bool = False,
+) -> None:
+    """
+    Export results to a custom R2 bucket.
+
+    Authentication is done via environment variables:
+    - CLOUDFLARE_ACCOUNT_ID
+    - R2_ACCESS_KEY_ID
+    - R2_SECRET_ACCESS_KEY
+    """
+    with console.status("[green]Uploading results to Cloudflare R2..."):
+        asyncio.run(r2_custom_(database_url, bucket_name, s3_dir, with_bundle))
 
 
 def _local(
@@ -83,4 +170,56 @@ def _local(
     console.log(f"[green]Saving results to {export_dir}...")
     exporter.local_files(
         database_url=database_url, export_dir=export_dir, with_bundle=with_bundle
+    )
+
+
+async def s3_(
+    database_url: str,
+    bucket_name: str,
+    country: common.Country,
+    city: common.City,
+    region: common.Region = None,
+    with_bundle: bool = False,
+) -> pathlib.Path:
+    """Export results to a S3 bucket following the PFB calver convention."""
+    return await exporter.export_to_s3_with_calver(
+        bucket_name, database_url, country, city, region, with_bundle
+    )
+
+
+async def s3_custom_(
+    database_url: common.DatabaseURL,
+    bucket_name: str,
+    s3_dir: pathlib.Path = pathlib.Path(),
+    with_bundle: bool = False,
+) -> pathlib.Path:
+    """Export results to a custom directory in a S3 bucket."""
+    return await exporter.export_to_s3_with_custom_dir(
+        bucket_name, database_url, s3_dir, with_bundle
+    )
+
+
+async def r2_(
+    database_url: common.DatabaseURL,
+    bucket_name: str,
+    country: common.Country,
+    city: common.City,
+    region: common.Region = None,
+    with_bundle: bool = False,
+) -> pathlib.Path:
+    """Export results to a R2 bucket following the PFB calver convention."""
+    return await exporter.export_to_r2_with_calver(
+        bucket_name, database_url, country, city, region, with_bundle
+    )
+
+
+async def r2_custom_(
+    database_url: common.DatabaseURL,
+    bucket_name: str,
+    r2_dir: pathlib.Path = pathlib.Path(),
+    with_bundle: bool = False,
+) -> pathlib.Path:
+    """Export results to a custom R2 bucket."""
+    return await exporter.export_to_r2_with_custom_dir(
+        bucket_name, database_url, r2_dir, with_bundle
     )

--- a/brokenspoke_analyzer/cli/run.py
+++ b/brokenspoke_analyzer/cli/run.py
@@ -14,7 +14,6 @@ from brokenspoke_analyzer.cli import (
 from brokenspoke_analyzer.core import (
     exporter,
 )
-from brokenspoke_analyzer.core.database import dbcore
 
 # Create the CLI app.
 app = typer.Typer()
@@ -48,26 +47,28 @@ def run(
     with_parts: common.ComputeParts = common.DEFAULT_COMPUTE_PARTS,
 ) -> None:
     """Run a full analysis."""
-    run_with.run_(
-        block_population=block_population,
-        block_size=block_size,
-        buffer=buffer,
-        cache_dir=cache_dir,
-        city_speed_limit=city_speed_limit,
-        city=city,
-        country=country,
-        data_dir=data_dir,
-        database_url=database_url,
-        fips_code=fips_code,
-        lodes_year=lodes_year,
-        max_trip_distance=max_trip_distance,
-        mirror=mirror,
-        no_cache=no_cache,
-        region=region,
-        retries=retries,
-        s3_bucket=s3_bucket,
-        s3_dir=s3_dir,
-        with_bundle=with_bundle,
-        with_export=with_export,
-        with_parts=with_parts,
+    asyncio.run(
+        run_with.run_(
+            block_population=block_population,
+            block_size=block_size,
+            buffer=buffer,
+            cache_dir=cache_dir,
+            city_speed_limit=city_speed_limit,
+            city=city,
+            country=country,
+            data_dir=data_dir,
+            database_url=database_url,
+            fips_code=fips_code,
+            lodes_year=lodes_year,
+            max_trip_distance=max_trip_distance,
+            mirror=mirror,
+            no_cache=no_cache,
+            region=region,
+            retries=retries,
+            s3_bucket=s3_bucket,
+            s3_dir=s3_dir,
+            with_bundle=with_bundle,
+            with_export=with_export,
+            with_parts=with_parts,
+        )
     )

--- a/brokenspoke_analyzer/cli/run_with.py
+++ b/brokenspoke_analyzer/cli/run_with.py
@@ -6,7 +6,6 @@ import subprocess
 import typing
 from importlib import resources
 
-import pandas as pd
 import rich
 import typer
 from loguru import logger
@@ -16,7 +15,6 @@ from brokenspoke_analyzer.cli import (
     common,
     configure,
     export,
-    importer,
     prepare,
 )
 from brokenspoke_analyzer.core import (
@@ -24,7 +22,6 @@ from brokenspoke_analyzer.core import (
     compute,
     exporter,
     ingestor,
-    runner,
     utils,
 )
 from brokenspoke_analyzer.core.database import dbcore
@@ -65,30 +62,31 @@ def compose(
             capture_output=not verbose,
         )
         configure.docker(database_url)
-        export_dir_: typing.Optional[pathlib.Path] = run_(
-            block_population=block_population,
-            block_size=block_size,
-            buffer=buffer,
-            cache_dir=cache_dir,
-            city_speed_limit=city_speed_limit,
-            city=city,
-            country=country,
-            data_dir=data_dir,
-            database_url=database_url,
-            export_dir=export_dir,
-            fips_code=fips_code,
-            lodes_year=lodes_year,
-            max_trip_distance=max_trip_distance,
-            mirror=mirror,
-            no_cache=no_cache,
-            region=region,
-            retries=retries,
-            s3_bucket=s3_bucket,
-            with_bundle=with_bundle,
-            with_export=with_export,
-            with_parts=with_parts,
+        export_dir_: typing.Optional[pathlib.Path] = asyncio.run(
+            run_(
+                block_population=block_population,
+                block_size=block_size,
+                buffer=buffer,
+                cache_dir=cache_dir,
+                city_speed_limit=city_speed_limit,
+                city=city,
+                country=country,
+                data_dir=data_dir,
+                database_url=database_url,
+                export_dir=export_dir,
+                fips_code=fips_code,
+                lodes_year=lodes_year,
+                max_trip_distance=max_trip_distance,
+                mirror=mirror,
+                no_cache=no_cache,
+                region=region,
+                retries=retries,
+                s3_bucket=s3_bucket,
+                with_bundle=with_bundle,
+                with_export=with_export,
+                with_parts=with_parts,
+            )
         )
-
     finally:
         subprocess.run(
             ["docker", "compose", "rm", "-sfv"], check=True, capture_output=True
@@ -100,7 +98,7 @@ def compose(
     return export_dir_
 
 
-def run_(
+async def run_(
     *,
     city: str,
     country: str,
@@ -162,7 +160,7 @@ def run_(
 
     # Prepare.
     logger.debug(f"{data_dir=}")
-    prepare.prepare_cmd(
+    await prepare.prepare_(
         block_population=block_population,
         block_size=block_size,
         cache_dir=cache_dir,
@@ -173,7 +171,7 @@ def run_(
         fips_code=fips_code,
         lodes_year=lodes_year,
         mirror=mirror,
-        no_cache=no_cache,
+        no_cache=bool(no_cache),
         region=region,
         retries=retries,
     )
@@ -183,7 +181,7 @@ def run_(
     with console.status("Importing..."):
         _, _, slug = analysis.osmnx_query(country, city, region)
         input_dir = data_dir / slug
-        importer.all(
+        await ingestor.all_wrapper(
             buffer=buffer,
             city=city,
             country=country,
@@ -191,7 +189,7 @@ def run_(
             database_url=database_url,
             fips_code=fips_code,
             lodes_year=lodes_year,
-            region=region,
+            region=region or country,
         )
 
     # Compute.
@@ -236,8 +234,12 @@ def run_(
             with_bundle=with_bundle,
         )
     elif with_export == exporter.Exporter.s3:
-        export_dir = export.s3(
-            bucket_name=s3_bucket,  # type: ignore
+        if not s3_bucket:
+            raise ValueError(
+                "`s3_bucket` must be specified when using custom S3 export"
+            )
+        export_dir = await export.s3_(
+            bucket_name=s3_bucket,
             city=city,
             country=country,
             database_url=database_url,
@@ -245,10 +247,42 @@ def run_(
             with_bundle=with_bundle,
         )
     elif with_export == exporter.Exporter.s3_custom:
-        export_dir = export.s3_custom(
-            bucket_name=s3_bucket,  # type: ignore
+        if not s3_bucket:
+            raise ValueError(
+                "`s3_bucket` must be specified when using custom S3 export"
+            )
+        if not s3_dir:
+            raise ValueError("`s3_dir` must be specified when using custom S3 export")
+        export_dir = await export.s3_custom_(
+            bucket_name=s3_bucket,
             database_url=database_url,
             s3_dir=s3_dir,
+            with_bundle=with_bundle,
+        )
+    elif with_export == exporter.Exporter.r2:
+        if not s3_bucket:
+            raise ValueError(
+                "`s3_bucket` must be specified when using custom R2 export"
+            )
+        export_dir = await export.r2_(
+            database_url=database_url,
+            bucket_name=s3_bucket,
+            country=country,
+            city=city,
+            region=region,
+            with_bundle=with_bundle,
+        )
+    elif with_export == exporter.Exporter.r2_custom:
+        if not s3_bucket:
+            raise ValueError(
+                "`s3_bucket` must be specified when using custom R2 export"
+            )
+        if not s3_dir:
+            raise ValueError("`s3_dir` must be specified when using custom R2 export")
+        export_dir = await export.r2_custom_(
+            database_url=database_url,
+            bucket_name=s3_bucket,
+            r2_dir=s3_dir,
             with_bundle=with_bundle,
         )
     return export_dir

--- a/brokenspoke_analyzer/core/exporter.py
+++ b/brokenspoke_analyzer/core/exporter.py
@@ -1,18 +1,46 @@
-"""Define functions to export the data to various destinations."""
+"""
+Define functions to export the data to various destinations.
 
+To export the data to an object store we use the `obstore` library, which
+provides a unified interface to interact with various object stores, including
+S3 and R2.
+
+The `export_store` function is the main entry point for exporting the data to an
+object store. It takes care of exporting the data to a local temporary directory
+and then uploading it to the destination store.
+
+However, since `obstore` does not have the concept of folders, we cannot
+create directories. For this use case, we leverage the native `boto3` library.
+Same goes for listing the objects, as `obstore` cannot differentiate between
+files and directories.
+
+References:
+- <https://github.com/developmentseed/obstore/issues/101>
+- <https://github.com/developmentseed/obstore/issues/644>
+"""
+
+from __future__ import annotations
+
+import os
 import pathlib
 import shutil
 import tempfile
 import typing
 from datetime import date
 from enum import Enum
+from typing import TYPE_CHECKING
 
 import boto3
+import yarl
 from loguru import logger
+from obstore.store import from_url
 from sqlalchemy.engine import Engine
 
 from brokenspoke_analyzer.core import runner
 from brokenspoke_analyzer.core.database import dbcore
+
+if TYPE_CHECKING:
+    from obstore.store import ObjectStore
 
 # Catalog the tables and associate them to an export format.
 TABLE_CATALOG = {
@@ -56,6 +84,8 @@ class Exporter(str, Enum):
     local = "local"
     s3 = "s3"
     s3_custom = "s3_custom"
+    r2 = "r2"
+    r2_custom = "r2_custom"
 
 
 def export_to_csv(
@@ -102,7 +132,7 @@ def auto_export(
     database_url: str,
 ) -> None:
     """
-    Export PostgreSQL/PostGIS tables to their repective files.
+    Export PostgreSQL/PostGIS tables to their respective files.
 
     Regular tables are exported into CSV files. GIS tables are exported either
     to geojson or sometimes shapefiles (or both).
@@ -130,11 +160,11 @@ def create_calver_directories(
     <country>/<egion>/<city>/YY.MM[.Micro]
     See https://calver.org/#scheme for more details.
 
-    Examples:
     * usa/tx/austin/23.08
     * usa/tx/austin/23.12.2
     * spain/valencia/valencia/23.08
 
+    Examples:
         >>> today = date.today()
         >>> calver = f"{today.strftime('%y.%m')}"
         >>> directory = create_calver_directories("usa", "austin", "tx")
@@ -160,7 +190,15 @@ def calver_base(
     date_override: typing.Optional[str] = None,
     base_dir: pathlib.Path = pathlib.Path(),
 ) -> pathlib.Path:
-    """Build the base part of the calver path."""
+    """
+    Build the base part of the calver path.
+
+    Examples:
+        >>> today = date.today()
+        >>> calver = f"{today.strftime('%y.%m')}"
+        >>> directory = calver_base("usa", "austin", "tx")
+        >>> assert directory == pathlib.Path(f"usa/tx/austin/{calver}")
+    """
     # Start with the base path.
     p = base_dir
 
@@ -204,7 +242,6 @@ def calver_revision(dirs: typing.Sequence[pathlib.Path]) -> int:
         >>> dirs.append(pathlib.Path('usa/new mexico/santa rosa/23.08.150'))
         >>> calver_revision(dirs)
         151
-
     """
     # Collect the directories with the suffixes.
     with_micro = [
@@ -218,89 +255,6 @@ def calver_revision(dirs: typing.Sequence[pathlib.Path]) -> int:
     # Otherwise get the highest micro and increment it.
     micro = max(with_micro) + 1
     return micro
-
-
-def create_calver_s3_directories(
-    bucket_name: str,
-    country: str,
-    city: str,
-    region: typing.Optional[str] = None,
-) -> pathlib.Path:
-    """Create the calver directory in the S3 bucket."""
-    # Initialize the S3 client.
-    s3 = boto3.resource("s3")
-    bucket = s3.Bucket(bucket_name)
-
-    # Create the calver directory.
-    s3_dir = calver_base(country, city, region)
-
-    # Check for any existing match.
-    matches = [
-        pathlib.Path(obj.key)
-        for obj in bucket.objects.filter(Prefix=str(s3_dir))
-        if str(s3_dir) in obj.key and obj.key.endswith("/")
-    ]
-
-    # In case there is already a calver folder, we must increment the revision.
-    if matches:
-        rev = calver_revision(matches)
-        s3_dir = pathlib.Path(f"{s3_dir}.{rev}/")
-
-    # Create the folder in the bucket.
-    bucket.put_object(Body="", Key=f"{s3_dir}/")
-
-    return s3_dir
-
-
-def s3_directories(
-    bucket_name: str, s3_dir: typing.Optional[pathlib.Path] = pathlib.Path()
-) -> pathlib.Path:
-    """Create a custom directory in the S3 bucket."""
-    # Make mypy happy.
-    if not s3_dir:
-        raise ValueError("`s3_dir` must be set")
-
-    # Initialize the S3 client.
-    s3 = boto3.resource("s3")
-    bucket = s3.Bucket(bucket_name)
-
-    # Create the folder in the bucket.
-    bucket.put_object(Body="", Key=f"{s3_dir}/")
-
-    return s3_dir
-
-
-def s3(
-    database_url: str,
-    bucket_name: str,
-    folder: pathlib.Path = pathlib.Path(),
-    with_bundle: bool = False,
-) -> None:
-    """Export PostgreSQL/PostGIS tables to an S3 Bucket."""
-    # Make mypy happy.
-    if not folder:
-        raise ValueError("`dest` must be set")
-
-    # Initialize the S3 client.
-    s3 = boto3.client("s3")
-
-    # Create a temporary directory to export the files.
-    with tempfile.TemporaryDirectory() as tmpdir_name:
-        tmpdir = pathlib.Path(tmpdir_name)
-        local_files(
-            database_url=database_url,
-            export_dir=tmpdir,
-            with_bundle=with_bundle,
-        )
-
-        # Upload each file one after the other.
-        for file in tmpdir.iterdir():
-            if not file.is_file():
-                continue
-
-            object_name = folder / file.name
-            logger.debug(f"Uploading file to s3://{bucket_name}/{object_name}")
-            s3.upload_file(file, bucket_name, str(object_name))
 
 
 def bundle(src_dir: pathlib.Path) -> pathlib.Path:
@@ -327,3 +281,293 @@ def local_files(
     # Bundle the result files into a zip file if needed.
     if with_bundle:
         bundle(export_dir)
+
+
+def get_s3_bucket(bucket_name: str) -> typing.Any:
+    """
+    Get the S3 bucket.
+
+    Authentication is done via AWS environment variables:
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
+    - AWS_REGION
+    - AWS_SESSION_TOKEN (optional)
+    """
+    # Initialize the S3 client.
+    s3 = boto3.resource(service_name="s3")
+    bucket = s3.Bucket(bucket_name)
+    return bucket
+
+
+def get_r2_bucket(bucket_name: str) -> typing.Any:
+    """
+    Get the R2 bucket.
+
+    Authentication is done via R2 environment variables:
+    - CLOUDFLARE_ACCOUNT_ID
+    - R2_ACCESS_KEY_ID
+    - R2_SECRET_ACCESS_KEY
+    """
+    r2_account_id = os.environ["CLOUDFLARE_ACCOUNT_ID"]
+    r2_access_key_id = os.environ["R2_ACCESS_KEY_ID"]
+    r2_secret_access_key = os.environ["R2_SECRET_ACCESS_KEY"]
+    s3 = boto3.resource(
+        service_name="s3",
+        endpoint_url=f"https://{r2_account_id}.r2.cloudflarestorage.com",
+        aws_access_key_id=r2_access_key_id,
+        aws_secret_access_key=r2_secret_access_key,
+        region_name="auto",
+    )
+    return s3.Bucket(bucket_name)
+
+
+def calver_directory_s3(
+    bucket: typing.Any,
+    country: str,
+    city: str,
+    region: typing.Optional[str] = None,
+) -> pathlib.Path:
+    """Create the calver directory in the S3 bucket."""
+    # Create the calver directory.
+    s3_dir = calver_base(country, city, region)
+
+    # Check for any existing match.
+    matches = [
+        pathlib.Path(obj.key)
+        for obj in bucket.objects.filter(Prefix=str(s3_dir))
+        if str(s3_dir) in obj.key and obj.key.endswith("/")
+    ]
+
+    # In case there is already a calver folder, we must increment the revision.
+    if matches:
+        rev = calver_revision(matches)
+        s3_dir = pathlib.Path(f"{s3_dir}.{rev}/")
+
+    # Return the calver folder.
+    return s3_dir
+
+
+def mkdir_calver_directory_s3(
+    bucket: typing.Any,
+    country: str,
+    city: str,
+    region: typing.Optional[str] = None,
+) -> pathlib.Path:
+    """Create the calver directory in the S3 bucket."""
+    # Create the calver directory.
+    s3_dir = calver_directory_s3(bucket, country, city, region)
+
+    # Create the folder in the bucket.
+    return mkdir_s3(bucket, s3_dir)
+
+
+def mkdir_s3(bucket: typing.Any, s3_dir: pathlib.Path = pathlib.Path()) -> pathlib.Path:
+    """Create a custom directory in the S3 bucket."""
+    bucket.put_object(Body="", Key=str(s3_dir).rstrip("/") + "/")
+    return s3_dir
+
+
+# ------------------------------------------------------------------------------
+# Below we are using `obstore` to implement store functions.
+def create_s3_store(
+    bucket_name: str, prefix: typing.Optional[pathlib.Path] = None
+) -> ObjectStore:
+    """
+    Create the S3 store.
+
+    Authentication is done via AWS environment variables:
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
+    - AWS_REGION
+    - AWS_SESSION_TOKEN (optional)
+    """
+    url = yarl.URL(f"s3://{bucket_name}")
+    if prefix:
+        url /= str(prefix)
+    logger.debug(f"Creating S3 store with URL: {url}")
+    return from_url(str(url))
+
+
+def create_r2_store(
+    bucket_name: str, prefix: typing.Optional[pathlib.Path] = None
+) -> ObjectStore:
+    """
+    Create the R2 store.
+
+    Authentication is done via environment variables:
+    - CLOUDFLARE_ACCOUNT_ID
+    - R2_ACCESS_KEY_ID
+    - R2_SECRET_ACCESS_KEY
+    """
+    account_id = os.environ["CLOUDFLARE_ACCOUNT_ID"]
+    access_key_id = os.environ["R2_ACCESS_KEY_ID"]
+    secret_access_key = os.environ["R2_SECRET_ACCESS_KEY"]
+    url = yarl.URL(f"https://{account_id}.r2.cloudflarestorage.com/{bucket_name}")
+    if prefix:
+        url /= str(prefix)
+    logger.debug(f"Creating R2 store with URL: {url}")
+    return from_url(
+        str(url),
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+    )
+
+
+async def upload_file(store: ObjectStore, path: pathlib.Path) -> None:
+    """Upload a file to the store."""
+    await store.put_async(str(path), path)
+
+
+async def export_to_store(
+    store: ObjectStore,
+    database_url: str,
+    with_bundle: bool = False,
+) -> None:
+    """Export PostgreSQL/PostGIS tables to a store."""
+    # Get bucket name.
+    # !!Remarks:
+    #   - HTTPStore, LocalStore and MemoryStore do not have a config attribute.
+    #   - AzureConfig has no key "bucket", uses "container_name" instead.
+    bucket_name = store.config["bucket"]  # type: ignore
+
+    # Create a temporary directory to export the files.
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        tmpdir = pathlib.Path(tmpdir_name)
+        local_files(
+            database_url=database_url,
+            export_dir=tmpdir,
+            with_bundle=with_bundle,
+        )
+
+        # Create a local store.
+        local_store = from_url(f"file://{tmpdir}")
+
+        # Upload each file sequentially.
+        for file in tmpdir.iterdir():
+            # Skip directories and non-files.
+            if not file.is_file():
+                continue
+
+            # Stream the file from the local store to the destination store.
+            logger.debug(f"Uploading {file.name} to the store...")
+            resp = await local_store.get_async(file.name)
+            await store.put_async(file.name, resp)
+
+
+async def export_to_s3_with_calver(
+    bucket_name: str,
+    database_url: str,
+    country: str,
+    city: str,
+    region: typing.Optional[str] = None,
+    with_bundle: bool = False,
+) -> pathlib.Path:
+    """Export PostgreSQL/PostGIS tables to a directory following the calver convention."""
+    # Get the S3 bucket.
+    bucket = get_s3_bucket(bucket_name)
+
+    # Create the calver directory in the store.
+    folder = mkdir_calver_directory_s3(bucket, country, city, region)
+    logger.debug(f"Exporting results to s3://{bucket_name}/{folder}...")
+
+    # Export the files to the store.
+    return await export_to_s3(
+        bucket_name=bucket_name,
+        folder=folder,
+        database_url=database_url,
+        with_bundle=with_bundle,
+    )
+
+
+async def export_to_s3_with_custom_dir(
+    bucket_name: str,
+    database_url: str,
+    custom_dir: pathlib.Path,
+    with_bundle: bool = False,
+) -> pathlib.Path:
+    """Export PostgreSQL/PostGIS tables to a custom directory."""
+    # Get the S3 bucket.
+    bucket = get_s3_bucket(bucket_name)
+
+    # Create the custom directory in the store.
+    mkdir_s3(bucket, custom_dir)
+
+    # Export the files to the store.
+    return await export_to_s3(
+        bucket_name=bucket_name,
+        folder=custom_dir,
+        database_url=database_url,
+        with_bundle=with_bundle,
+    )
+
+
+async def export_to_s3(
+    bucket_name: str,
+    folder: pathlib.Path,
+    database_url: str,
+    with_bundle: bool = False,
+) -> pathlib.Path:
+    """Export PostgreSQL/PostGIS tables to a S3 directory."""
+    # Export the files to the store.
+    store = create_s3_store(bucket_name, folder)
+    await export_to_store(store, database_url, with_bundle)
+    return folder
+
+
+async def export_to_r2_with_calver(
+    bucket_name: str,
+    database_url: str,
+    country: str,
+    city: str,
+    region: typing.Optional[str] = None,
+    with_bundle: bool = False,
+) -> pathlib.Path:
+    """Export PostgreSQL/PostGIS tables to a directory following the calver convention."""
+    # Get the R2 bucket.
+    bucket = get_r2_bucket(bucket_name)
+
+    # Create the calver directory in the store.
+    folder = mkdir_calver_directory_s3(bucket, country, city, region)
+
+    # Export the files to the store.
+    return await export_to_r2(
+        bucket_name=bucket_name,
+        folder=folder,
+        database_url=database_url,
+        with_bundle=with_bundle,
+    )
+
+
+async def export_to_r2_with_custom_dir(
+    bucket_name: str,
+    database_url: str,
+    custom_dir: pathlib.Path,
+    with_bundle: bool = False,
+) -> pathlib.Path:
+    """Export PostgreSQL/PostGIS tables to a custom directory."""
+    # Get the R2 bucket.
+    bucket = get_r2_bucket(bucket_name)
+
+    # Create the custom directory in the store.
+    mkdir_s3(bucket, custom_dir)
+
+    # Export the files to the store.
+    return await export_to_r2(
+        bucket_name=bucket_name,
+        folder=custom_dir,
+        database_url=database_url,
+        with_bundle=with_bundle,
+    )
+
+
+async def export_to_r2(
+    bucket_name: str,
+    folder: pathlib.Path,
+    database_url: str,
+    with_bundle: bool = False,
+) -> pathlib.Path:
+    """Export PostgreSQL/PostGIS tables to a R2 directory."""
+    # Export the files to the store.
+    store = create_r2_store(bucket_name, folder)
+    await export_to_store(store, database_url, with_bundle)
+    return folder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,8 @@ dev = [
   "xdoctest>=1.3.2,<2",
   "pandas-stubs>=3.0.0.260204,<4",
   "types-beautifulsoup4>=4.12.0.20250516",
+  "pytest-asyncio>=1.3.0",
+  "types-boto3>=1.42.78",
   "minijinja>=2.19.0",
 ]
 

--- a/utils/bna-batch.py
+++ b/utils/bna-batch.py
@@ -87,7 +87,7 @@ OSM_CACHE_FILE_SUFFIX = ".pbf.md5"
 
 
 def main(
-    batch_file: BatchFile = "cities.csv",
+    batch_file: BatchFile = pathlib.Path("cities.csv"),
     lodes_year: common.LODESYear = None,
     parts: common.ComputeParts = [constant.ComputePart.MEASURE],
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -272,6 +272,18 @@ wheels = [
 ]
 
 [[package]]
+name = "botocore-stubs"
+version = "1.42.41"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-awscrt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/a8/a26608ff39e3a5866c6c79eda10133490205cbddd45074190becece3ff2a/botocore_stubs-1.42.41.tar.gz", hash = "sha256:dbeac2f744df6b814ce83ec3f3777b299a015cbea57a2efc41c33b8c38265825", size = 42411, upload-time = "2026-02-03T20:46:14.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/76/cab7af7f16c0b09347f2ebe7ffda7101132f786acb767666dce43055faab/botocore_stubs-1.42.41-py3-none-any.whl", hash = "sha256:9423110fb0e391834bd2ed44ae5f879d8cb370a444703d966d30842ce2bcb5f0", size = 66759, upload-time = "2026-02-03T20:46:13.02Z" },
+]
+
+[[package]]
 name = "bpython"
 version = "0.26"
 source = { registry = "https://pypi.org/simple" }
@@ -322,6 +334,7 @@ dev = [
     { name = "myst-parser" },
     { name = "pandas-stubs" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
@@ -334,6 +347,7 @@ dev = [
     { name = "sphinx-copybutton" },
     { name = "sqlfluff" },
     { name = "types-beautifulsoup4" },
+    { name = "types-boto3" },
     { name = "types-colorama" },
     { name = "types-decorator" },
     { name = "types-jsonschema" },
@@ -374,6 +388,7 @@ dev = [
     { name = "myst-parser", specifier = ">=5.0.0,<6" },
     { name = "pandas-stubs", specifier = ">=3.0.0.260204,<4" },
     { name = "pytest", specifier = ">=9.0.1,<10" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0,<8" },
     { name = "pytest-mock", specifier = ">=3.15.1,<4" },
     { name = "pytest-rerunfailures", specifier = "~=16.1" },
@@ -386,6 +401,7 @@ dev = [
     { name = "sphinx-copybutton", specifier = ">=0.5.2,<0.6" },
     { name = "sqlfluff", specifier = ">=4.1.0,<5" },
     { name = "types-beautifulsoup4", specifier = ">=4.12.0.20250516" },
+    { name = "types-boto3", specifier = ">=1.42.78" },
     { name = "types-colorama", specifier = ">=0.4.15.20250801,<0.5" },
     { name = "types-decorator", specifier = ">=5.2.0.20251101,<6" },
     { name = "types-jsonschema", specifier = ">=4.26.0.20260402,<5" },
@@ -1869,6 +1885,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2658,6 +2686,15 @@ wheels = [
 ]
 
 [[package]]
+name = "types-awscrt"
+version = "0.31.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/26/0aa563e229c269c528a3b8c709fc671ac2a5c564732fab0852ac6ee006cf/types_awscrt-0.31.3.tar.gz", hash = "sha256:09d3eaf00231e0f47e101bd9867e430873bc57040050e2a3bd8305cb4fc30865", size = 18178, upload-time = "2026-03-08T02:31:14.569Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/e5/47a573bbbd0a790f8f9fe452f7188ea72b212d21c9be57d5fc0cbc442075/types_awscrt-0.31.3-py3-none-any.whl", hash = "sha256:e5ce65a00a2ab4f35eacc1e3d700d792338d56e4823ee7b4dbe017f94cfc4458", size = 43340, upload-time = "2026-03-08T02:31:13.38Z" },
+]
+
+[[package]]
 name = "types-beautifulsoup4"
 version = "4.12.0.20250516"
 source = { registry = "https://pypi.org/simple" }
@@ -2667,6 +2704,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/d1/32b410f6d65eda94d3dfb0b3d0ca151f12cb1dc4cef731dcf7cbfd8716ff/types_beautifulsoup4-4.12.0.20250516.tar.gz", hash = "sha256:aa19dd73b33b70d6296adf92da8ab8a0c945c507e6fb7d5db553415cc77b417e", size = 16628, upload-time = "2025-05-16T03:09:09.93Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/79/d84de200a80085b32f12c5820d4fd0addcbe7ba6dce8c1c9d8605e833c8e/types_beautifulsoup4-4.12.0.20250516-py3-none-any.whl", hash = "sha256:5923399d4a1ba9cc8f0096fe334cc732e130269541d66261bb42ab039c0376ee", size = 16879, upload-time = "2025-05-16T03:09:09.051Z" },
+]
+
+[[package]]
+name = "types-boto3"
+version = "1.42.88"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore-stubs" },
+    { name = "types-s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/1c/908dcdcf9859f0c848b0f9dd41783e2d6edffe6e4a25429836a7af426c47/types_boto3-1.42.88.tar.gz", hash = "sha256:5e449c9d030313d006d17d0fba9c8bac517d5250c9b40e258b5ad9604a30e2fd", size = 102881, upload-time = "2026-04-10T19:55:53.833Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/ec/605fc0a70224d2781c09b7057e522ca9a64431435cdb5fe1f14a7fe80c5c/types_boto3-1.42.88-py3-none-any.whl", hash = "sha256:1be5a0259f7352332256373686e9c8906a8d143d4678eb380b4402202fc9ef86", size = 70510, upload-time = "2026-04-10T19:55:48.852Z" },
 ]
 
 [[package]]
@@ -2748,6 +2798,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d2/cb/7fdc1982b117d216a9ebbe4ecc6619690991c48f994d93dee7888f459976/types-python-slugify-8.0.2.20240310.tar.gz", hash = "sha256:5157b508c7fed587520c70d77f62aea0fafdc6620893c2ec8972f13a1faf5560", size = 3661, upload-time = "2024-03-10T02:19:03.582Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/6d/873300a60133e51b284a5287a618d3d948a65160e3954b90b3dc5e562667/types_python_slugify-8.0.2.20240310-py3-none-any.whl", hash = "sha256:0efec18b802c69ebd22dcee55c91afaeaa80e1e40ddd66ccabf69fd42ce87b74", size = 3566, upload-time = "2024-03-10T02:19:02.575Z" },
+]
+
+[[package]]
+name = "types-s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/64/42689150509eb3e6e82b33ee3d89045de1592488842ddf23c56957786d05/types_s3transfer-0.16.0.tar.gz", hash = "sha256:b4636472024c5e2b62278c5b759661efeb52a81851cde5f092f24100b1ecb443", size = 13557, upload-time = "2025-12-08T08:13:09.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/27/e88220fe6274eccd3bdf95d9382918716d312f6f6cef6a46332d1ee2feff/types_s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:1c0cd111ecf6e21437cb410f5cddb631bfb2263b77ad973e79b9c6d0cb24e0ef", size = 19247, upload-time = "2025-12-08T08:13:08.426Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Leverages the Obstore library in order to be able to export results to
more data stores.

The S3 export was rewritten and the R2 export was added.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
