### PR TITLE
Honor --with-bundle flag for all exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ and this project adheres to [Semantic Versioning].
 [#1055]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/1055
 [#1056]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/1056
 [#1057]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/1057
-[3.1.0]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/3.1.0
+[3.1.0]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/3.1.0
 
 ## [3.0.0] - 2026-01-28
 
@@ -104,7 +105,8 @@ grateful for every contribution, no matter the size.
 [#1007]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/1007
 [#1010]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/1010
 [#1011]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/1011
-[3.0.0]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/3.0.0
+[3.0.0]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/3.0.0
 
 ## [2.6.5] - 2025-10-04
 
@@ -117,7 +119,8 @@ grateful for every contribution, no matter the size.
 [#947]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/947
 [#948]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/948
 [#949]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/949
-[2.6.5]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.6.5
+[2.6.5]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.6.5
 
 ## [2.6.4] - 2025-09-05
 
@@ -133,7 +136,8 @@ grateful for every contribution, no matter the size.
 [#913]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/913
 [#914]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/914
 [#925]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/925
-[2.6.4]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.6.4
+[2.6.4]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.6.4
 
 ## [2.6.3] - 2025-08-06
 
@@ -144,7 +148,8 @@ grateful for every contribution, no matter the size.
 
 [#895]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/895
 [#910]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/910
-[2.6.3]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.6.3
+[2.6.3]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.6.3
 
 ## [2.6.2] - 2025-07-23
 
@@ -153,7 +158,8 @@ grateful for every contribution, no matter the size.
 - Excluded golf courses paths from bicycle infrastructure. [#889]
 
 [#889]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/889
-[2.6.2]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.6.2
+[2.6.2]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.6.2
 
 ## [2.6.1] - 2025-06-29
 
@@ -162,7 +168,8 @@ grateful for every contribution, no matter the size.
 - Fixed a bug preventing to export the results in some cases. [#883]
 
 [#883]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/883
-[2.6.1]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.6.1
+[2.6.1]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.6.1
 
 ## [2.6.0] - 2025-06-18
 
@@ -201,7 +208,8 @@ grateful for every contribution, no matter the size.
 [#856]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/856
 [#864]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/864
 [#870]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/870
-[2.6.0]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.6.0
+[2.6.0]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.6.0
 
 ## [2.5.0] - 2025-03-22
 
@@ -222,7 +230,8 @@ grateful for every contribution, no matter the size.
 [#800]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/800
 [#820]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/820
 [#832]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/832
-[2.5.0]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.5.0
+[2.5.0]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.5.0
 
 ## [2.4.0] - 2024-11-13
 
@@ -240,7 +249,8 @@ grateful for every contribution, no matter the size.
 [#726]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/726
 [#727]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/727
 [#729]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/729
-[2.4.0]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.4.0
+[2.4.0]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.4.0
 
 ## [2.3.0] - 2024-09-17
 
@@ -265,7 +275,8 @@ Thank you for joining our community and making a difference!
 [#648]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/648
 [#654]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/654
 [#660]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/660
-[2.3.0]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.3.0
+[2.3.0]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.3.0
 
 ## [2.2.1] - 2024-07-06
 
@@ -274,7 +285,8 @@ Thank you for joining our community and making a difference!
 - Fixed the Docker image. [#652]
 
 [#652]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/652
-[2.2.1]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.2.1
+[2.2.1]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.2.1
 
 ## [2.2.0] - 2024-07-06 [YANKED]
 
@@ -283,7 +295,8 @@ Thank you for joining our community and making a difference!
 - Added the ability to bundle the results. [#617]
 
 [#617]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/617
-[2.2.0]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.2.0
+[2.2.0]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.2.0
 
 ## [2.1.2] - 2024-05-14
 
@@ -292,13 +305,15 @@ Thank you for joining our community and making a difference!
 - Added missing parameter to the `run` command. [#603]
 
 [#603]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/603
-[2.1.2]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.1.2
+[2.1.2]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.1.2
 
 ## [2.1.1] - 2024-03-16
 
 This is a release to fix the release workflows.
 
-[2.1.1]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.1.1
+[2.1.1]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.1.1
 
 ## [2.1.0] - 2024-03-16
 
@@ -313,7 +328,8 @@ This is a release to fix the release workflows.
 
 [#518]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/518
 [#542]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/542
-[2.1.0]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.1.0
+[2.1.0]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.1.0
 
 ## [2.0.0] - 2024-02-19
 
@@ -337,7 +353,8 @@ up-to-date changelog, ensuring that all future enhancements and features will be
 meticulously documented to provide transparency and facilitate user
 understanding.
 
-[2.0.0]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.0.0
+[2.0.0]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.0.0
 
 ## [2.0.0-alpha] - 2023-09-16
 
@@ -383,7 +400,8 @@ understanding.
 [#321]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/321
 [#329]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/329
 [#330]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/330
-[2.0.0-alpha]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.0.0-alpha
+[2.0.0-alpha]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/2.0.0-alpha
 
 ## [1.3.0] - 2023-08-20
 
@@ -420,7 +438,8 @@ understanding.
 [#240]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/240
 [#259]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/259
 [#272]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/272
-[1.3.0]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.3.0
+[1.3.0]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.3.0
 
 ## [1.2.1] - 2023-06-18
 
@@ -431,7 +450,8 @@ understanding.
 
 [#205]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/205
 [#206]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/206
-[1.2.1]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.2.1
+[1.2.1]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.2.1
 
 ## [1.2.0] - 2023-06-14
 
@@ -451,7 +471,8 @@ understanding.
 [#152]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/152
 [#190]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/190
 [#191]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/191
-[1.2.0]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.2.0
+[1.2.0]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.2.0
 
 ## [1.1.0] - 2022-10-08
 
@@ -464,13 +485,15 @@ understanding.
 - Updated the analyzer image to 0.16.1. [#52]
 
 [#52]: https://github.com/PeopleForBikes/brokenspoke-analyzer/pull/52
-[1.1.0]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.1.0
+[1.1.0]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.1.0
 
 ## [1.0.0] - 2022-08-14
 
 First stable version.
 
-[1.0.0]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.0.0
+[1.0.0]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.0.0
 
 ## [1.0.0-rc.1] - 2022-08-07
 
@@ -480,5 +503,6 @@ the world (although the analyzer will fail for some of them).
 The tool is still a bit rough on the edges, that is why this is a release
 candidate, but the quirks will be ironned out for 1.0.0.
 
-[1.0.0-rc.1]: https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.0.0-rc.1
+[1.0.0-rc.1]:
+  https://github.com/PeopleForBikes/brokenspoke-analyzer/releases/tag/1.0.0-rc.1
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html

--- a/brokenspoke_analyzer/cli/common.py
+++ b/brokenspoke_analyzer/cli/common.py
@@ -26,14 +26,14 @@ DEFAULT_RETRIES = 2
 
 # Default Typer Arguments/Options.
 BlockPopulation = Annotated[
-    typing.Optional[int],
+    int,
     typer.Option(help="population of a synthetic block for non-US cities"),
 ]
 BlockSize = Annotated[
-    typing.Optional[int],
+    int,
     typer.Option(help="size of a synthetic block for non-US cities (in meters)"),
 ]
-Buffer = Annotated[typing.Optional[int], typer.Option(help="define the buffer area")]
+Buffer = Annotated[int, typer.Option(help="define the buffer area")]
 CacheDir = Annotated[
     typing.Optional[pathlib.Path],
     typer.Option(
@@ -78,11 +78,11 @@ export_dir_kwargs = dict(
 )
 ExportDirArg = Annotated[pathlib.Path, typer.Argument(**export_dir_kwargs)]
 ExportDirOpt = Annotated[pathlib.Path, typer.Option(**export_dir_kwargs)]
-FIPSCode = Annotated[typing.Optional[str], typer.Argument(help="US city FIPS code")]
+FIPSCode = Annotated[str, typer.Argument(help="US city FIPS code")]
 LODESYear = Annotated[
     typing.Optional[int], typer.Option(help="year to use to retrieve US job data")
 ]
-MaxTripDistance = Annotated[typing.Optional[int], typer.Option()]
+MaxTripDistance = Annotated[int, typer.Option()]
 Mirror = Annotated[
     typing.Optional[str],
     typer.Option(help="use a mirror to fetch the US census files"),
@@ -95,10 +95,11 @@ Region = Annotated[
     typer.Argument(help="world region (e.g., state, province, community, etc...)"),
 ]
 Retries = Annotated[
-    typing.Optional[int],
+    int,
     typer.Option(help="number of times to retry downloading files"),
 ]
 SpeedLimit = Annotated[
-    typing.Optional[int], typer.Option(help="override the default speed limit (in mph)")
+    int, typer.Option(help="override the default speed limit (in mph)")
 ]
 State = Annotated[typing.Optional[str], typer.Argument(help="US state")]
+WithBundle = Annotated[bool, typer.Option(help="bundle all the files in a zip archive")]

--- a/brokenspoke_analyzer/cli/export.py
+++ b/brokenspoke_analyzer/cli/export.py
@@ -14,10 +14,6 @@ from brokenspoke_analyzer.core import exporter
 app = typer.Typer()
 console = rich.get_console()
 
-WithBundle = Annotated[
-    typing.Optional[bool], typer.Argument(help="bundle all the files in a zip archive")
-]
-
 
 @app.command()
 def local(
@@ -26,7 +22,7 @@ def local(
     city: common.City,
     region: common.Region = None,
     export_dir: common.ExportDirArg = common.DEFAULT_EXPORT_DIR,
-    with_bundle: WithBundle = False,
+    with_bundle: common.WithBundle = False,
 ) -> pathlib.Path:
     """Export results to a directory following the PFB calver convention."""
     dir_ = exporter.create_calver_directories(
@@ -41,7 +37,7 @@ def local(
 def local_custom(
     database_url: common.DatabaseURL,
     export_dir: common.ExportDirArg,
-    with_bundle: typing.Optional[bool] = False,
+    with_bundle: common.WithBundle = False,
 ) -> None:
     """Export results to a custom directory."""
     _local(database_url=database_url, export_dir=export_dir, with_bundle=with_bundle)
@@ -54,7 +50,7 @@ def s3(
     country: common.Country,
     city: common.City,
     region: common.Region = None,
-    with_bundle: typing.Optional[bool] = False,
+    with_bundle: common.WithBundle = False,
 ) -> pathlib.Path:
     """Export results to a S3 bucket following the PFB calver convention."""
     with console.status("[green]Uploading results to AWS S3..."):
@@ -70,7 +66,7 @@ def s3_custom(
     database_url: common.DatabaseURL,
     bucket_name: str,
     s3_dir: typing.Optional[pathlib.Path] = pathlib.Path(),
-    with_bundle: typing.Optional[bool] = False,
+    with_bundle: common.WithBundle = False,
 ) -> pathlib.Path:
     """Export results to a custom S3 bucket."""
     with console.status("[green]Uploading results to AWS S3..."):
@@ -82,7 +78,7 @@ def s3_custom(
 def _local(
     database_url: str,
     export_dir: pathlib.Path,
-    with_bundle: typing.Optional[bool] = False,
+    with_bundle: bool = False,
 ) -> None:
     console.log(f"[green]Saving results to {export_dir}...")
     exporter.local_files(

--- a/brokenspoke_analyzer/cli/run.py
+++ b/brokenspoke_analyzer/cli/run.py
@@ -43,8 +43,8 @@ def run(
         typing.Optional[str], typer.Option(help="S3 bucket name where to export")
     ] = None,
     s3_dir: typing.Optional[pathlib.Path] = None,
-    with_bundle: typing.Optional[bool] = False,
-    with_export: typing.Optional[exporter.Exporter] = exporter.Exporter.local,
+    with_bundle: bool = False,
+    with_export: exporter.Exporter = exporter.Exporter.local,
     with_parts: common.ComputeParts = common.DEFAULT_COMPUTE_PARTS,
 ) -> None:
     """Run a full analysis."""

--- a/brokenspoke_analyzer/cli/run_with.py
+++ b/brokenspoke_analyzer/cli/run_with.py
@@ -52,8 +52,8 @@ def compose(
     no_cache: common.NoCache = False,
     retries: common.Retries = common.DEFAULT_RETRIES,
     s3_bucket: typing.Optional[str] = None,
-    with_bundle: typing.Optional[bool] = False,
-    with_export: typing.Optional[exporter.Exporter] = exporter.Exporter.local,
+    with_bundle: bool = False,
+    with_export: exporter.Exporter = exporter.Exporter.local,
     with_parts: common.ComputeParts = common.DEFAULT_COMPUTE_PARTS,
 ) -> typing.Optional[pathlib.Path]:
     """Manage Docker Compose when running the analysis."""
@@ -105,24 +105,24 @@ def run_(
     city: str,
     country: str,
     database_url: str,
-    block_population: typing.Optional[int] = common.DEFAULT_BLOCK_POPULATION,
-    block_size: typing.Optional[int] = common.DEFAULT_BLOCK_SIZE,
-    buffer: typing.Optional[int] = common.DEFAULT_BUFFER,
+    block_population: int = common.DEFAULT_BLOCK_POPULATION,
+    block_size: int = common.DEFAULT_BLOCK_SIZE,
+    buffer: int = common.DEFAULT_BUFFER,
     cache_dir: typing.Optional[pathlib.Path] = None,
-    city_speed_limit: typing.Optional[int] = common.DEFAULT_CITY_SPEED_LIMIT,
-    data_dir: typing.Optional[pathlib.Path] = common.DEFAULT_DATA_DIR,
-    export_dir: typing.Optional[pathlib.Path] = common.DEFAULT_EXPORT_DIR,
-    fips_code: typing.Optional[str] = common.DEFAULT_CITY_FIPS_CODE,
+    city_speed_limit: int = common.DEFAULT_CITY_SPEED_LIMIT,
+    data_dir: pathlib.Path = common.DEFAULT_DATA_DIR,
+    export_dir: pathlib.Path = common.DEFAULT_EXPORT_DIR,
+    fips_code: str = common.DEFAULT_CITY_FIPS_CODE,
     lodes_year: typing.Optional[int] = None,
-    max_trip_distance: typing.Optional[int] = common.DEFAULT_MAX_TRIP_DISTANCE,
+    max_trip_distance: int = common.DEFAULT_MAX_TRIP_DISTANCE,
     mirror: common.Mirror = None,
     no_cache: common.NoCache = False,
     region: typing.Optional[str] = None,
-    retries: typing.Optional[int] = common.DEFAULT_RETRIES,
+    retries: int = common.DEFAULT_RETRIES,
     s3_bucket: typing.Optional[str] = None,
     s3_dir: typing.Optional[pathlib.Path] = None,
-    with_bundle: typing.Optional[bool] = False,
-    with_export: typing.Optional[exporter.Exporter] = exporter.Exporter.local,
+    with_bundle: bool = False,
+    with_export: exporter.Exporter = exporter.Exporter.local,
     with_parts: common.ComputeParts = common.DEFAULT_COMPUTE_PARTS,
 ) -> typing.Optional[pathlib.Path]:
     """Run an analysis."""
@@ -242,11 +242,13 @@ def run_(
             country=country,
             database_url=database_url,
             region=region,
+            with_bundle=with_bundle,
         )
     elif with_export == exporter.Exporter.s3_custom:
         export_dir = export.s3_custom(
             bucket_name=s3_bucket,  # type: ignore
             database_url=database_url,
             s3_dir=s3_dir,
+            with_bundle=with_bundle,
         )
     return export_dir

--- a/brokenspoke_analyzer/core/exporter.py
+++ b/brokenspoke_analyzer/core/exporter.py
@@ -273,8 +273,8 @@ def s3_directories(
 def s3(
     database_url: str,
     bucket_name: str,
-    folder: typing.Optional[pathlib.Path] = pathlib.Path(),
-    with_bundle: typing.Optional[bool] = False,
+    folder: pathlib.Path = pathlib.Path(),
+    with_bundle: bool = False,
 ) -> None:
     """Export PostgreSQL/PostGIS tables to an S3 Bucket."""
     # Make mypy happy.
@@ -315,7 +315,7 @@ def bundle(src_dir: pathlib.Path) -> pathlib.Path:
 def local_files(
     database_url: str,
     export_dir: pathlib.Path,
-    with_bundle: typing.Optional[bool] = False,
+    with_bundle: bool = False,
 ) -> None:
     """Export result files into a local directory."""
     # Prepare the output directory.


### PR DESCRIPTION
The `--with-bundle` flag was ignored for non-local exports. This patch
ensures it now works for all types of exports.

Drive-by:
- Fixes the optional argument syntax in the Typer commands.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
