### PR TITLE
Add SourceAdapters to BNAStore

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -106,6 +106,7 @@ Provide review feedback using:
 - Should-fix
 - Questions
 - Suggested verification commands\*\* (must be realistic for this repo)
+  - Run the verifications using the commands defined in our justfile
 
 ## Guidance boundaries
 

--- a/brokenspoke_analyzer/cli/common.py
+++ b/brokenspoke_analyzer/cli/common.py
@@ -76,8 +76,8 @@ export_dir_kwargs = dict(
     readable=True,
     help="directory where to export the results",
 )
-ExportDirArg = Annotated[pathlib.Path, typer.Argument(**export_dir_kwargs)]
-ExportDirOpt = Annotated[pathlib.Path, typer.Option(**export_dir_kwargs)]
+ExportDirArg = Annotated[pathlib.Path, typer.Argument(**export_dir_kwargs)]  # ty:ignore[no-matching-overload]
+ExportDirOpt = Annotated[pathlib.Path, typer.Option(**export_dir_kwargs)]  # ty:ignore[no-matching-overload]
 FIPSCode = Annotated[str, typer.Argument(help="US city FIPS code")]
 LODESYear = Annotated[
     typing.Optional[int], typer.Option(help="year to use to retrieve US job data")

--- a/brokenspoke_analyzer/cli/prepare.py
+++ b/brokenspoke_analyzer/cli/prepare.py
@@ -112,7 +112,7 @@ async def prepare_(
     # Compute the city slug.
     _, _, slug = analysis.osmnx_query(country, city, region)
 
-    # Prepare the output directory.
+    # Prepare the data directory.
     data_dir /= slug
     data_dir.mkdir(parents=True, exist_ok=True)
     logger.info(f"{data_dir=}")
@@ -137,29 +137,34 @@ async def prepare_(
     boundary_file = data_dir / f"{slug}.shp"
 
     # Download the OSM region file.
+    state_abbrev, state_fips, _ = analysis.derive_state_info(region)
     osm_region = region if region else country
-    console.log(
-        f"[green]Fetching the OSM region file for {osm_region}...",
+
+    # Prepare the caching strategy.
+    caching_strategy = datastore.CacheType.USER_CACHE
+    if no_cache:
+        caching_strategy = datastore.CacheType.NONE
+    elif cache_dir:
+        caching_strategy = datastore.CacheType.CUSTOM
+
+    bna_store = datastore.BNADataStore(
+        data_dir, caching_strategy, mirror=mirror, custom_dir=cache_dir
     )
-    with console.status("Downloading..."):
-        try:
-            if not region:
-                raise ValueError
-            region_file_path = retryer(analysis.retrieve_region_file, region, data_dir)
-        except ValueError:
-            region_file_path = retryer(analysis.retrieve_region_file, country, data_dir)
-    region_file_path_md5 = pathlib.Path(str(region_file_path) + ".md5")
-    if not utils.file_checksum_ok(region_file_path, region_file_path_md5):
-        raise ValueError("Invalid OSM region file")
+
+    async with aiohttp.ClientSession() as session:
+        console.log(
+            f"[green]Fetching the OSM region file for {osm_region}...",
+        )
+        with console.status("Downloading..."):
+            region_file_name = await bna_store.download_osm_data(session, osm_region)
+        await bna_store.download_osm_data(session, osm_region)
 
     # Reduce the osm file with osmium.
     console.log(f"[green]Reducing the OSM file for {city} with osmium...")
     polygon_file = data_dir / f"{slug}.geojson"
+    region_file_path = data_dir / region_file_name
     pfb_osm_file = pathlib.Path(f"{slug}.osm")
     analysis.prepare_city_file(data_dir, region_file_path, polygon_file, pfb_osm_file)
-
-    # Retrieve the state info if needed.
-    state_abbrev, state_fips, _ = analysis.derive_state_info(region)
 
     # Perform some specific operations for non-US cities.
     if state_fips == runner.NON_US_STATE_FIPS:
@@ -181,17 +186,6 @@ async def prepare_(
         )
         analysis.change_speed_limit(data_dir, city, state_abbrev, city_speed_limit)
     else:
-        # Prepare the caching strategy.
-        caching_strategy = datastore.CacheType.USER_CACHE
-        if no_cache:
-            caching_strategy = datastore.CacheType.NONE
-        elif cache_dir:
-            caching_strategy = datastore.CacheType.CUSTOM
-
-        bna_store = datastore.BNADataStore(
-            data_dir, caching_strategy, mirror=mirror, custom_dir=cache_dir
-        )
-
         # Fetch the data.
         async with aiohttp.ClientSession() as session:
             console.log("[green]Fetching US state speed limits...")

--- a/brokenspoke_analyzer/core/analysis.py
+++ b/brokenspoke_analyzer/core/analysis.py
@@ -10,7 +10,7 @@ import zipfile
 
 import geopandas as gpd
 import numpy as np
-import pygris  # type: ignore
+import pygris
 import shapely
 from loguru import logger
 from osmnx import (
@@ -108,6 +108,8 @@ def state_info(state: str) -> tuple[str, str]:
     if not st:
         raise ValueError(f"cannot find state info for: {state}, {abbrev}")
     fips = st.fips
+    if not fips:
+        raise ValueError(f"cannot find FIPS code for: {state}, {abbrev}")
 
     return (abbrev, fips)
 
@@ -264,7 +266,7 @@ def create_synthetic_population(
             ],
         },
         crs=utils.PSEUDO_MERCATOR_CRS,
-    )
+    )  # ty:ignore[no-matching-overload]
 
     return grid.to_crs(area.crs)
 

--- a/brokenspoke_analyzer/core/compute.py
+++ b/brokenspoke_analyzer/core/compute.py
@@ -32,7 +32,7 @@ def execute_sqlfile_with_substitutions(
     if bind_params:
         binding_names = sorted(bind_params.keys(), key=len, reverse=True)
         for binding_name in binding_names:
-            param = bind_params[binding_name]
+            param = bind_params[binding_name]  # ty:ignore[invalid-argument-type]
             substitute = param if param is not None else "NULL"
             statements = statements.replace(f":{binding_name}", f"{substitute}")
     dbcore.execute_query(engine, statements)
@@ -351,7 +351,7 @@ def connectivity(
     # Access: population
     logger.info("METRICS: Access: population")
     sql_script = sql_connectivity_script_dir / "access_population.sql"
-    bind_params: typing.Mapping[str, float] = {  # type: ignore
+    bind_params: typing.Mapping[str, float] = {
         "max_score": 1,
         "step1": 0.03,
         "score1": 0.1,
@@ -369,7 +369,7 @@ def connectivity(
         dbcore.execute_sql_file(engine, sql_script)
 
         sql_script = sql_connectivity_script_dir / "access_jobs.sql"
-        bind_params: typing.Mapping[str, float] = {  # type: ignore
+        bind_params: typing.Mapping[str, float] = {
             "max_score": 1,
             "step1": 0.03,
             "score1": 0.1,
@@ -402,7 +402,7 @@ def connectivity(
             "nb_output_srid": output_srid,
         }
         execute_sqlfile_with_substitutions(engine, sql_script, bind_params)
-    destinations = ["schools", "social_services", "supermarkets"]  # type: ignore
+    destinations = ["schools", "social_services", "supermarkets"]
     for destination in destinations:
         sql_script = sql_destination_script_dir / f"{destination}.sql"
         bind_params = {"nb_output_srid": output_srid}
@@ -428,9 +428,9 @@ def connectivity(
     for access in accesses:
         sql_script = sql_connectivity_script_dir / f"access_{access.name}.sql"
         bind_params = {
-            "first": access.first,  # type: ignore
-            "second": access.second,  # type: ignore
-            "third": access.third,  # type: ignore
+            "first": access.first,
+            "second": access.second,
+            "third": access.third,
             "max_score": access.max_score,
         }
         execute_sqlfile_with_substitutions(engine, sql_script, bind_params)
@@ -438,8 +438,8 @@ def connectivity(
     # Access_trails.
     sql_script = sql_connectivity_script_dir / "access_trails.sql"
     bind_params = {
-        "first": 0.7,  # type: ignore
-        "second": 0.2,  # type: ignore
+        "first": 0.7,
+        "second": 0.2,
         "third": 0,
         "max_score": 1,
         "min_path_length": path_constraint.min_length,

--- a/brokenspoke_analyzer/core/datasource.py
+++ b/brokenspoke_analyzer/core/datasource.py
@@ -1,0 +1,360 @@
+"""Represent the source adapter module."""
+
+import pathlib
+import typing
+import zipfile
+from abc import (
+    ABC,
+    abstractmethod,
+)
+from collections import abc
+
+import aiohttp
+import yarl
+from loguru import logger
+from obstore.store import ObjectStore
+
+from brokenspoke_analyzer import pyrosm
+from brokenspoke_analyzer.core import (
+    downloader,
+    file_utils,
+    utils,
+)
+from brokenspoke_analyzer.core.utils import unzip
+from brokenspoke_analyzer.pyrosm import data
+
+
+class SourceAdapter(ABC):
+    """Abstract base class for data source adapters."""
+
+    # Define the URL of the source.
+    SOURCE_URL: typing.Optional[yarl.URL] = None
+
+    def __init__(self, mirror: typing.Optional[str] = None):
+        """Initialize the SourceAdapter.
+
+        Example:
+            >>> adapter = CitySpeedLimitAdapter()
+            >>> adapter.mirror is None
+            True
+        """
+        self.mirror = mirror
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Return the source name.
+
+        Example:
+            >>> adapter = CitySpeedLimitAdapter()
+            >>> adapter.name
+            'city_speed_limits'
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def files(self) -> abc.Sequence[pathlib.Path]:
+        """Return the source data files.
+
+        Example:
+            >>> adapter = StateSpeedLimitAdapter()
+            >>> len(adapter.files)
+            1
+        """
+        pass
+
+    @property
+    def source_url(self) -> yarl.URL:
+        """Return the source URL."""
+        if self.SOURCE_URL is None:
+            raise ValueError(f"{self.__class__.__name__} must define SOURCE_URL")
+        return yarl.URL(self.mirror) if self.mirror else self.SOURCE_URL
+
+    @property
+    def urls(self) -> abc.Sequence[yarl.URL]:
+        """Return the source data URLs."""
+        return [self.source_url / str(f) for f in self.files]
+
+    @property
+    def subpath(self) -> pathlib.Path:
+        """Return the sub-directory for the source data."""
+        return pathlib.Path(self.name)
+
+    def prepare(self, datastore: pathlib.Path) -> None:
+        """Prepare the data files.
+
+        Example:
+            >>> import tempfile
+            >>> adapter = CitySpeedLimitAdapter()
+            >>> with tempfile.TemporaryDirectory() as tmpdir:
+            >>>     adapter.prepare(pathlib.Path(tmpdir))
+        """
+        pass
+
+    def validate(self, datastore: pathlib.Path) -> None:
+        """Validate downloaded data.
+
+        Raises `ValueError` if a required file does not exist or is empty.
+
+        Example:
+            >>> import tempfile, pathlib
+            >>> adapter = CitySpeedLimitAdapter()
+            >>> with tempfile.TemporaryDirectory() as tmpdir:
+            >>>     try:
+            >>>         adapter.validate(pathlib.Path(tmpdir))
+            >>>     except ValueError as e:
+            >>>         print("Validation failed as expected")
+            Validation failed as expected
+        """
+        files = [datastore / f for f in self.files]
+        for f in files:
+            if not f.exists():
+                raise ValueError(f"{f} does not exist")
+            if f.stat().st_size < 1:
+                raise ValueError(f"{f} is empty")
+
+
+class CensusAdapter(SourceAdapter):
+    """Adapter for US Census blocks data."""
+
+    SOURCE_URL = yarl.URL("https://www2.census.gov/geo/tiger/TIGER2020/TABBLOCK20")
+
+    def __init__(
+        self,
+        fips: str,
+        mirror: typing.Optional[str] = None,
+    ):
+        """Initialize the CensusAdapter."""
+        super().__init__(mirror)
+        self.fips = fips
+
+    @property
+    def name(self) -> str:
+        """Return the source name."""
+        return "census"
+
+    @property
+    def files(self) -> abc.Sequence[pathlib.Path]:
+        """
+        Return the source data files.
+
+        Example:
+            >>> adapter = CensusAdapter("06")
+            >>> adapter.files[0].name
+            tl_2020_06_tabblock20.zip
+        """
+        return [pathlib.Path(f"tl_2020_{self.fips}_tabblock20.zip")]
+
+    def prepare(self, datastore: pathlib.Path) -> None:
+        """Prepare the data files."""
+        if len(self.files) != 1:
+            raise ValueError(
+                f"only 1 file was expected, {len(self.files)} found: {self.files}"
+            )
+        tabblk_file = datastore / self.files[0]
+        output_dir = datastore.resolve()
+
+        # Unzip it.
+        unzip(tabblk_file.resolve(strict=True), output_dir, False)
+
+        # Rename the tabulation block files to "population".
+        # But keep the original file.
+        tabblk2020_files = output_dir.glob(f"{tabblk_file.stem}.*")
+        for file in tabblk2020_files:
+            file.rename(output_dir / f"population{file.suffix}")
+
+    def validate(self, datastore: pathlib.Path) -> None:
+        """Validate downloaded data."""
+        for f in datastore.glob(f"population.*"):
+            if not f.exists():
+                raise ValueError(f"{f} does not exist")
+            if f.stat().st_size < 1:
+                raise ValueError(f"{f} is empty")
+
+
+class CitySpeedLimitAdapter(SourceAdapter):
+    """Adapter for city speed limit data."""
+
+    SOURCE_URL = yarl.URL("https://s3.amazonaws.com/pfb-public-documents")
+
+    @property
+    def name(self) -> str:
+        """Return the source name."""
+        return "city_speed_limits"
+
+    @property
+    def files(self) -> abc.Sequence[pathlib.Path]:
+        """
+        Return the source data files.
+
+        Example:
+            >>> adapter = CitySpeedLimitAdapter()
+            >>> adapter.files[0].name
+            city_fips_speed.csv
+        """
+        return [pathlib.Path("city_fips_speed.csv")]
+
+
+class OSMAdapter(SourceAdapter):
+    """Adapter for Openstreetmap data."""
+
+    def __init__(
+        self,
+        region: str,
+        mirror: typing.Optional[str] = None,
+    ):
+        """Initialize the CensusAdapter."""
+        super().__init__(mirror)
+        self.region = region
+
+    @property
+    def name(self) -> str:
+        """Return the source name."""
+        return "osm"
+
+    @property
+    def files(self) -> abc.Sequence[pathlib.Path]:
+        """Return the source data files."""
+        return [pathlib.Path(f.name) for f in self.urls]
+
+    @property
+    def urls(self) -> abc.Sequence[yarl.URL]:
+        """Return the source data URLs."""
+        ds = self.get_dataset()
+        return [yarl.URL(ds["url"]), yarl.URL(ds["url"] + ".md5")]
+
+    def get_dataset(self) -> typing.Any:
+        """Retrieve the OSM dataset metadata."""
+        # Define the region.
+        region = self.region
+
+        # As per https://github.com/PeopleForBikes/brokenspoke-analyzer/issues/863
+        # we must define an exception for the countries of Malaysia, Singapore and
+        # Brunei as they have been grouped together in the Geofabrik dataset.
+        if region in {"malaysia", "singapore", "brunei"}:
+            region = "malaysia_singapore_brunei"
+
+        # Normalize and fetch the dataset metadata.
+        dataset = utils.normalize_unicode_name(region)
+        return data.get_download_data(dataset)
+
+    def validate(self, datastore: pathlib.Path) -> None:
+        """Validate downloaded data."""
+        ds = self.get_dataset()
+        region_file = datastore / ds["name"]
+        region_file_md5 = region_file.with_suffix(f"{region_file.suffix}.md5")
+        if not utils.file_checksum_ok(region_file, region_file_md5):
+            raise ValueError(f"invalid OSM region file: {region_file}")
+
+
+class StateSpeedLimitAdapter(SourceAdapter):
+    """Adapter for state speed limit data."""
+
+    SOURCE_URL = yarl.URL("https://s3.amazonaws.com/pfb-public-documents")
+
+    @property
+    def name(self) -> str:
+        """Return the source name."""
+        return "state_speed_limits"
+
+    @property
+    def files(self) -> abc.Sequence[pathlib.Path]:
+        """Return the source data files."""
+        return [pathlib.Path("state_fips_speed.csv")]
+
+
+class LodesAdapter(SourceAdapter):
+    """
+    Adapter for LODES data.
+
+    Download employment data from the US census website: https://lehd.ces.census.gov/.
+
+    LODES stands for LEHD Origin-Destination Employment Statistics.
+
+    OD means Origin-Data, which represents the jobs that are associated with
+    both a home census block and a work census block.
+
+    The filename is composed of the following parts:
+    ``[ST]_od_[PART]_[TYPE]_[YEAR].csv.gz``.
+
+    * [ST] = lowercase, 2-letter postal code for a chosen state
+    * [PART] = Part of the state file, can have a value of either "main" or
+        "aux".
+        Complimentary parts of the state file, the main part includes jobs with
+        both workplace and residence in the state and the aux part includes jobs
+        with the workplace in the state and the residence outside of the state.
+    * [TYPE] = Job Type, can have a value of "JT00 for All Jobs, "JT01" for
+        Primary Jobs, "JT02" for All Private Jobs, "JT03" for Private Primary
+        Jobs, "JT04" for All Federal Jobs, or "JT05" for Federal Primary Jobs.
+    * [YEAR] = Year of job data. Can have the value of 2002-2020 for most
+        states.
+
+    As an example, the main OD file of Primary Jobs in 2007 for California would
+    be the file: ``ca_od_main_JTO1_2007.csv.gz``.
+
+    More information about the formast can be found on the website:
+    https://lehd.ces.census.gov/data/#lodes.
+    """
+
+    SOURCE_URL = yarl.URL("https://lehd.ces.census.gov/data/lodes/LODES8/")
+
+    def __init__(
+        self,
+        state_abbrev: str,
+        lodes_year: int,
+        mirror: typing.Optional[str] = None,
+    ):
+        """Initialize the CensusAdapter."""
+        super().__init__(mirror)
+        self.state_abbrev = state_abbrev
+        self.lodes_year = lodes_year
+
+    @property
+    def name(self) -> str:
+        """Return the source name."""
+        return "lodes"
+
+    @property
+    def files(self) -> abc.Sequence[pathlib.Path]:
+        """
+        Return the source data files.
+
+        Example:
+            >>> adapter = LodesAdapter("ca", 2019)
+            >>> adapter.files[0].name
+            ca_od_main_JT00_2019.csv.gz
+        """
+        return [
+            pathlib.Path(
+                f"{self.state_abbrev.lower()}_od_{part}_JT00_{self.lodes_year}.csv.gz"
+            )
+            for part in ["main", "aux"]
+        ]
+
+    @property
+    def urls(self) -> abc.Sequence[yarl.URL]:
+        """Return the source data URLs."""
+        return [
+            yarl.URL(self.source_url / self.state_abbrev / "od" / str(f))
+            for f in self.files
+        ]
+
+    def prepare(self, datastore: pathlib.Path) -> None:
+        """Prepare the data files."""
+        for f in self.files:
+            target = datastore / f.stem
+            logger.debug(f"Preparing {f} into {target}")
+            if target.exists():
+                logger.debug(f"{target} already exists, skipping decompression")
+                continue
+            utils.gunzip(datastore / f, target)
+
+    def validate(self, datastore: pathlib.Path) -> None:
+        """Validate downloaded data."""
+        for f in self.files:
+            target = datastore / f.stem
+            if not target.exists():
+                raise ValueError(f"{target} does not exist")
+            if target.stat().st_size < 1:
+                raise ValueError(f"{target} is empty")

--- a/brokenspoke_analyzer/core/datastore.py
+++ b/brokenspoke_analyzer/core/datastore.py
@@ -15,6 +15,7 @@ from obstore.store import (
 )
 
 from brokenspoke_analyzer.core import (
+    datasource,
     downloader,
     file_utils,
     utils,
@@ -25,9 +26,6 @@ if TYPE_CHECKING:
 
 
 CHUNK_SIZE = 5 * 1024 * 1024  # 5MB
-PFB_PUBLIC_DOCUMENTS_URL = "https://s3.amazonaws.com/pfb-public-documents"
-LODES_202x_URL = "https://lehd.ces.census.gov/data/lodes/LODES8/"
-TIGER_2020_URL = "https://www2.census.gov/geo/tiger/TIGER2020/TABBLOCK20"
 
 
 def exists(store: ObjectStore, path: str) -> bool:
@@ -121,14 +119,21 @@ class BNADataStore:
         """Check whether a file already exists in the data store."""
         return exists(self.store, path)
 
-    async def copy_to_store(self, path: str) -> None:
+    async def copy_to_store(
+        self, path: str, destination: typing.Optional[str] = None
+    ) -> None:
         """Copy a file from the cache to the store."""
         if not exists(self.cache, path):
             raise FileNotFoundError(f"{path} was not found in the cache")
-        if exists(self.store, path):
+
+        # Change the destination path if we do not want it to match the source path.
+        destination_path = destination if destination else path
+
+        # Copy the file if it does not already exist in the store.
+        if exists(self.store, destination_path):
             return
         res = await self.cache.get_async(path)
-        await self.store.put_async(path, res)
+        await self.store.put_async(destination_path, res)
 
     async def fetch_to_cache(
         self, session: aiohttp.ClientSession, url: str, path: str
@@ -144,96 +149,84 @@ class BNADataStore:
         async with session.get(url) as resp:
             await self.cache.put_async(path, resp.content.iter_chunked(CHUNK_SIZE))
 
-    async def fetch(self, session: aiohttp.ClientSession, url: str, path: str) -> None:
+    async def fetch(
+        self,
+        session: aiohttp.ClientSession,
+        url: str,
+        path: str,
+        cache_only: bool = False,
+    ) -> None:
         """Fetch a file from a URL."""
         await self.fetch_to_cache(session, url, path)
-        await self.copy_to_store(path)
+        if not cache_only:
+            await self.copy_to_store(path)
 
-    async def download_state_speed_limits(self, session: aiohttp.ClientSession) -> None:
+    async def fetch_from_source(
+        self,
+        session: aiohttp.ClientSession,
+        source: datasource.SourceAdapter,
+        cache_only: bool = False,
+    ) -> None:
+        """Fetch file(s) from a SourceAdapter."""
+        for url in source.urls:
+            path = str(source.subpath / url.name)
+            await self.fetch_to_cache(session, str(url), path)
+            if not cache_only:
+                await self.copy_to_store(path, url.name)
+        if not cache_only:
+            datastore = self.store.prefix
+            source.prepare(datastore)
+            source.validate(datastore)
+
+    async def download_state_speed_limits(
+        self, session: aiohttp.ClientSession, cache_only: bool = False
+    ) -> None:
         """Download the state speed limits."""
-        state_speed_csv = "state_fips_speed.csv"
-        root_url = self.mirror if self.mirror else PFB_PUBLIC_DOCUMENTS_URL
-        url = f"{root_url}/{state_speed_csv}"
-        await self.fetch(session, url, state_speed_csv)
+        s = datasource.StateSpeedLimitAdapter()
+        await self.fetch_from_source(session, s, cache_only=cache_only)
 
-    async def download_city_speed_limits(self, session: aiohttp.ClientSession) -> None:
+    async def download_city_speed_limits(
+        self, session: aiohttp.ClientSession, cache_only: bool = False
+    ) -> None:
         """Download the city speed limits."""
-        city_speed_csv = "city_fips_speed.csv"
-        root_url = self.mirror if self.mirror else PFB_PUBLIC_DOCUMENTS_URL
-        url = f"{root_url}/{city_speed_csv}"
-        await self.fetch(session, url, city_speed_csv)
+        s = datasource.CitySpeedLimitAdapter()
+        await self.fetch_from_source(session, s)
 
     async def download_lodes_data(
         self,
         session: aiohttp.ClientSession,
         state_abbrev: str,
-        lodes_year: int | None,
+        lodes_year: typing.Optional[int] = None,
+        cache_only: bool = False,
     ) -> None:
-        """
-        Download employment data from the US census website: https://lehd.ces.census.gov/.
-
-        LODES stands for LEHD Origin-Destination Employment Statistics.
-
-        OD means Origin-Data, which represents the jobs that are associated with
-        both a home census block and a work census block.
-
-        The filename is composed of the following parts:
-        ``[ST]_od_[PART]_[TYPE]_[YEAR].csv.gz``.
-
-        * [ST] = lowercase, 2-letter postal code for a chosen state
-        * [PART] = Part of the state file, can have a value of either "main" or
-            "aux".
-            Complimentary parts of the state file, the main part includes jobs with
-            both workplace and residence in the state and the aux part includes jobs
-            with the workplace in the state and the residence outside of the state.
-        * [TYPE] = Job Type, can have a value of "JT00 for All Jobs, "JT01" for
-            Primary Jobs, "JT02" for All Private Jobs, "JT03" for Private Primary
-            Jobs, "JT04" for All Federal Jobs, or "JT05" for Federal Primary Jobs.
-        * [YEAR] = Year of job data. Can have the value of 2002-2020 for most
-            states.
-
-        As an example, the main OD file of Primary Jobs in 2007 for California would
-        be the file: ``ca_od_main_JTO1_2007.csv.gz``.
-
-        More information about the formast can be found on the website:
-        https://lehd.ces.census.gov/data/#lodes.
-        """
+        """Download employment data from the US census website."""
         state_abbrev = state_abbrev.lower()
+
         # Puerto Rico is part of the US but the US Census Bureau never collected
         # employment data. As a result we are just skipping it.
-
         if state_abbrev in {"pr"}:
             logger.warning(f"There is no LODES data for the state of '{state_abbrev}'")
             return
-
-        lodes_url = f"{LODES_202x_URL}/{state_abbrev}/od"
-        root_url = self.mirror if self.mirror else lodes_url
 
         # Autodetect latest LODES year if not specified.
         if not lodes_year:
             lodes_year = await downloader.autodetect_latest_lodes_year(
                 session, state_abbrev
             )
-
-        for part in ["main", "aux"]:
-            lodes_gz = f"{state_abbrev}_od_{part.lower()}_JT00_{lodes_year}.csv.gz"
-            lodes_csv = f"{state_abbrev}_od_{part.lower()}_JT00_{lodes_year}.csv"
-            url = f"{root_url}/{lodes_gz}"
-            await self.fetch(session, url, lodes_gz)
-
-            # Gunzip it in the store and delete the gz file.
-            utils.gunzip(self.store.prefix / lodes_gz, self.store.prefix / lodes_csv)
+        s = datasource.LodesAdapter(state_abbrev, lodes_year, self.mirror)
+        await self.fetch_from_source(session, s, cache_only=cache_only)
 
     async def download_2020_census_blocks(
-        self, session: aiohttp.ClientSession, fips: str
+        self, session: aiohttp.ClientSession, fips: str, cache_only: bool = False
     ) -> None:
         """Download a 2020 census tabulation block code for a specific state."""
-        tabblk2020_zip = f"tl_2020_{fips}_tabblock20.zip"
-        root_url = self.mirror if self.mirror else TIGER_2020_URL
-        url = f"{root_url}/{tabblk2020_zip}"
-        await self.fetch(session, url, tabblk2020_zip)
+        s = datasource.CensusAdapter(fips, self.mirror)
+        await self.fetch_from_source(session, s, cache_only=cache_only)
 
-        # Unzip and rename the tabulation block files to "population".
-        utils.prepare_census_blocks(
-            self.store.prefix / tabblk2020_zip, self.store.prefix
-        )
+    async def download_osm_data(
+        self, session: aiohttp.ClientSession, region: str, cache_only: bool = False
+    ) -> pathlib.Path:
+        """Retrieve the region file from Geofabrik or BBike."""
+        s = datasource.OSMAdapter(region, self.mirror)
+        await self.fetch_from_source(session, s, cache_only=cache_only)
+        return pathlib.Path(s.urls[0].name)

--- a/brokenspoke_analyzer/core/downloader.py
+++ b/brokenspoke_analyzer/core/downloader.py
@@ -5,6 +5,7 @@ import re
 import typing
 
 import aiohttp
+import yarl
 from bs4 import BeautifulSoup
 from loguru import logger
 
@@ -231,9 +232,9 @@ async def autodetect_latest_lodes_year(
     # employment data. As a result we are just skipping it.
     PART = "aux"
     TYPE = "JT00"
-    lehd_url = f"{LODES_URL}/{state_abbrev.lower()}/od"
+    lehd_url = yarl.URL(LODES_URL) / state_abbrev.lower() / "od"
     logger.debug(f"Looking up latest LODES year for {state_abbrev} {PART} {TYPE}")
-    html_dir = await fetch_text(session=session, url=lehd_url)
+    html_dir = await fetch_text(session=session, url=str(lehd_url))
     latest_year = parse_latest_lodes_year(html_dir, state_abbrev, PART, TYPE)
-    logger.debug(f"Found year: {latest_year}")
+    logger.debug(f"Found latest LODES year: {latest_year}")
     return latest_year

--- a/brokenspoke_analyzer/core/exporter.py
+++ b/brokenspoke_analyzer/core/exporter.py
@@ -428,7 +428,7 @@ async def export_to_store(
     # !!Remarks:
     #   - HTTPStore, LocalStore and MemoryStore do not have a config attribute.
     #   - AzureConfig has no key "bucket", uses "container_name" instead.
-    bucket_name = store.config["bucket"]  # type: ignore
+    bucket_name = store.config["bucket"]
 
     # Create a temporary directory to export the files.
     with tempfile.TemporaryDirectory() as tmpdir_name:

--- a/brokenspoke_analyzer/core/runner.py
+++ b/brokenspoke_analyzer/core/runner.py
@@ -5,7 +5,7 @@ import multiprocessing
 import pathlib
 import subprocess
 import typing
-import urllib
+import urllib.parse
 
 from loguru import logger
 

--- a/brokenspoke_analyzer/core/utils.py
+++ b/brokenspoke_analyzer/core/utils.py
@@ -50,16 +50,19 @@ def gunzip(
     """Gunzip a file into a specific target."""
     # Decompress it.
     gzip_file = gzip_file.resolve(strict=True)
+    logger.debug(f"Decompressing {gzip_file} to {target}")
     with gzip.open(gzip_file, "rb") as f:
         try:
             content = f.read()
         except gzip.BadGzipFile as e:
             delete_after = True
-            raise RuntimeError("Bad Gzip file. Try downloading the file again.") from e
+            raise RuntimeError(
+                f"Bad Gzip file: {gzip_file}. Try downloading it again."
+            ) from e
         except EOFError as e:
             delete_after = True
             raise RuntimeError(
-                "End of file error.  Try downloading the file again."
+                f"End of file error: {gzip_file}. Try downloading it again."
             ) from e
         else:
             target.resolve().write_bytes(content)

--- a/brokenspoke_analyzer/pyrosm/data/__init__.py
+++ b/brokenspoke_analyzer/pyrosm/data/__init__.py
@@ -24,34 +24,8 @@ from brokenspoke_analyzer.pyrosm.data.geofabrik import (
 )
 from brokenspoke_analyzer.pyrosm.utils.download import download
 
-__all__ = ["available", "get_data", "get_path"]
+__all__ = ["available", "get_download_data"]
 _module_path = os.path.dirname(__file__)
-_package_files = {"test_pbf": "test.osm.pbf", "helsinki_pbf": "Helsinki.osm.pbf"}
-
-# Static test data
-_helsinki_region_pbf = {
-    "name": "Helsinki_region.osm.pbf",
-    "url": "https://gist.github.com/HTenkanen/"
-    "02dcfce32d447e65024d93d39ddb1812/"
-    "raw/5fe7ffb625f091591d8c29128a9e3b37870a5012/"
-    "Helsinki_region.osm.pbf",
-}
-
-_helsinki_history_pbf = {
-    "name": "Helsinki-sample.osh.pbf",
-    "url": "https://gist.github.com/HTenkanen/"
-    "02dcfce32d447e65024d93d39ddb1812/"
-    "raw/885154d451772bef6ac5160027589ddddc97272c/"
-    "helsinki-internal.osh.pbf",
-}
-
-_helsinki_test_history_pbf = {
-    "name": "Helsinki-test.osh.pbf",
-    "url": "https://gist.github.com/HTenkanen/"
-    "02dcfce32d447e65024d93d39ddb1812/"
-    "raw/219f5655ff3ce0a80f84ce424534dfbcdae77792/"
-    "helsinki-test.osh.pbf",
-}
 
 
 class DataSources:
@@ -96,15 +70,6 @@ class DataSources:
             self._all_sources += self.subregions.__dict__[subregion].available
 
         self._all_sources = [src.lower() for src in self._all_sources]
-
-        # Static data for Helsinki Region
-        # that should be able to download
-        # (needed for tests)
-        self._all_sources += [
-            "helsinki_region_pbf",
-            "helsinki_history_pbf",
-            "helsinki_test_history_pbf",
-        ]
         self._all_sources = list(set(self._all_sources))
 
 
@@ -112,30 +77,12 @@ class DataSources:
 sources = DataSources()
 
 available = {
-    "test_data": list(_package_files.keys())
-    + ["helsinki_region_pbf", "helsinki_history_pbf", "helsinki_test_history_pbf"],
     "regions": {
         k: v for k, v in sources.available.items() if k not in ["cities", "subregions"]
     },
     "subregions": sources.subregions.available,
     "cities": sources.cities.available,
 }
-
-
-def retrieve(data, update, directory):
-    download(
-        url=data["url"] + ".md5",
-        filename=data["name"] + ".md5",
-        update=update,
-        target_dir=directory,
-    )
-    return download(
-        url=data["url"],
-        filename=data["name"],
-        update=update,
-        target_dir=directory,
-    )
-
 
 def search_source(name):
     for source, available in sources.available.items():
@@ -153,7 +100,7 @@ def search_source(name):
     raise ValueError(f"Could not retrieve url for '{name}'.")
 
 
-def get_data(dataset, update=False, directory=None):
+def get_download_data(dataset):
     """
     Get the path to a PBF data file, and download the data if needed.
 
@@ -162,57 +109,23 @@ def get_data(dataset, update=False, directory=None):
     dataset : str
         The name of the dataset. Run ``pyrosm.data.available`` for
         all available options.
-
-    update : bool
-        Whether the PBF file should be downloaded/updated if the dataset
-        with the same name exists in the temp.
-
-    directory : str (optional)
-        Path to a directory where the PBF data will be downloaded.
-        (does not apply for test data sets bundled with the package).
     """
-    if not isinstance(dataset, str):
-        raise ValueError(f"'dataset' should be text. Got {dataset}.")
-    dataset = dataset.lower().strip()
-
-    if dataset in _package_files:
-        return os.path.abspath(os.path.join(_module_path, _package_files[dataset]))
-
-    if dataset == "helsinki_region_pbf":
-        return retrieve(_helsinki_region_pbf, update, directory)
-
-    if dataset == "helsinki_history_pbf":
-        return retrieve(_helsinki_history_pbf, update, directory)
-
-    if dataset == "helsinki_test_history_pbf":
-        return retrieve(_helsinki_test_history_pbf, update, directory)
-
     if dataset in sources._all_sources:
-        return retrieve(search_source(dataset), update, directory)
+        return search_source(dataset)
 
     # Users might pass city names with spaces (e.g. Rio De Janeiro)
     if dataset.replace(" ", "") in sources._all_sources:
-        return retrieve(search_source(dataset.replace(" ", "")), update, directory)
+        return search_source(dataset.replace(" ", ""))
 
     # Users might pass country names without underscores (e.g. North America)
     if dataset.replace(" ", "_") in sources._all_sources:
-        return retrieve(search_source(dataset.replace(" ", "_")), update, directory)
+        return search_source(dataset.replace(" ", "_"))
 
     # Users might pass country names with dashes instead of underscores
     # (e.g. canary-islands)
     if dataset.replace("-", "_") in sources._all_sources:
-        return retrieve(search_source(dataset.replace("-", "_")), update, directory)
+        return search_source(dataset.replace("-", "_"))
 
     msg = f"The dataset '{dataset}' is not available. "
     msg += f"Available datasets are {', '.join(sources._all_sources)}"
     raise ValueError(msg)
-
-
-# Keep temporarily for backward compatibility
-def get_path(dataset, update=False, directory=None):
-    warnings.warn(
-        "'get_path()' is deprecated, use 'get_data()' instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return get_data(dataset, update, directory)

--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ lint-python:
     uv run isort --check .
     uv run ruff format --check {{ src_dir }} {{ utils_dir }}
     uv run ruff check {{ src_dir }} {{ utils_dir }}
-    uv run mypy {{ src_dir }}
+    uv run ty check {{ src_dir }}
 
 # Lint SQL files.
 lint-sql:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,20 +12,21 @@ license = "MIT"
 dependencies = [
   "aiohttp>=3.13.5,<4",
   "beautifulsoup4>=4.14.3",
-  "boto3>=1.42.82,<2",
+  "boto3>=1.42.88,<2",
   "geopandas>=1.1.3,<2",
   "loguru>=0.7.3,<0.8",
-  "obstore>=0.9.2",
+  "obstore>=0.9.3",
   "osmnx>=2.1.0,<3",
-  "platformdirs>=4.9.4",
+  "platformdirs>=4.9.6",
   "pygris>=0.2.1",
   "python-dotenv>=1.2.2,<2",
   "python-slugify>=8.0.4,<9",
-  "rich>=14.3.3,<15",
+  "rich>=15.0.0,<16",
   "sqlalchemy[asyncio, postgresql_psycopg]>=2.0.49,<3",
   "tenacity>=9.1.4,<10",
   "typer>=0.24.1,<0.25",
   "us>=3.2.0,<4",
+  "yarl>=1.23.0",
 ]
 
 [project.scripts]
@@ -37,32 +38,32 @@ dev = [
   "furo>=2025.12.19,<2026",
   "isort>=8.0.1,<9",
   "jupyterlab>=4.5.6,<5",
-  "mypy>=1.20.0,<2",
   "myst-parser>=5.0.0,<6",
-  "pytest>=9.0.1,<10",
+  "pytest>=9.0.3,<10",
   "pytest-cov>=7.1.0,<8",
   "pytest-mock>=3.15.1,<4",
   "pytest-rerunfailures~=16.1",
   "pytest-socket>=0.7.0,<0.8",
   "pytest-xdist>=3.8.0,<4",
-  "ruff>=0.15.9",
+  "ruff>=0.15.10",
   "Sphinx>=9.1.0,<10",
   "sphinx-autobuild>=2025.8.25,<2026",
-  "sphinx-autodoc-typehints>=3.9.11,<4",
+  "sphinx-autodoc-typehints>=3.10.0,<4",
   "sphinx-copybutton>=0.5.2,<0.6",
   "sqlfluff>=4.1.0,<5",
-  "types-colorama>=0.4.15.20250801,<0.5",
-  "types-decorator>=5.2.0.20251101,<6",
-  "types-jsonschema>=4.26.0.20260402,<5",
-  "types-pygments>=2.19.0.20260402,<3",
+  "types-colorama>=0.4.15.20260408,<0.5",
+  "types-decorator>=5.2.0.20260408,<6",
+  "types-jsonschema>=4.26.0.20260408,<5",
+  "types-pygments>=2.20.0.20260408,<3",
   "types-python-slugify>=8.0.2.20240310,<9",
-  "types-six>=1.17.0.20251009,<2",
+  "types-six>=1.17.0.20260408,<2",
   "xdoctest>=1.3.2,<2",
   "pandas-stubs>=3.0.0.260204,<4",
   "types-beautifulsoup4>=4.12.0.20250516",
   "pytest-asyncio>=1.3.0",
-  "types-boto3>=1.42.78",
+  "types-boto3>=1.42.91",
   "minijinja>=2.19.0",
+  "ty>=0.0.29",
 ]
 
 [tool.isort]
@@ -167,6 +168,16 @@ ignore_words_regex = "ST_."
 
 [tool.sqlfluff.rules.layout.long_lines]
 ignore_comment_lines = true
+
+[tool.ty.src]
+exclude = [
+  "brokenspoke_analyzer/pyrosm/**",
+  "boto3",
+  "geopandas",
+  "osmnx",
+  "shapely",
+  "us",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/utils/bna-batch.py
+++ b/utils/bna-batch.py
@@ -101,10 +101,6 @@ def main(
     # Enable cache.
     os.environ["BNA_CACHING_STRATEGY"] = "USER_CACHE"
 
-    # Simulate a caching mechanism for OSM data.
-    osm_cache = OSM_CACHE_DIR
-    osm_cache.mkdir(parents=True, exist_ok=True)
-
     # Prepare the Rich output.
     console = rich.get_console()
 
@@ -112,7 +108,7 @@ def main(
     retryer = Retrying(
         stop=stop_after_attempt(MAX_RETRIES),
         reraise=True,
-        before=before_log(logger, logging.DEBUG),  # type: ignore
+        before=before_log(logger, logging.DEBUG),
     )
 
     # Read the CSV file.
@@ -125,31 +121,6 @@ def main(
             city = row["city"]
             region = row.get("region") if row.get("region") else country
             fips_code = row["fips_code"]
-
-            # Download the OSM data into the cache if necessary.
-            console.log(
-                f"[green]Caching the OSM region file for {region}...",
-            )
-            with console.status("Downloading..."):
-                try:
-                    cached_region_file = retryer(
-                        analysis.retrieve_region_file, region, osm_cache
-                    )
-                    cached_region_file_md5 = cached_region_file.with_suffix(
-                        OSM_CACHE_FILE_SUFFIX
-                    )
-                except Exception as e:
-                    print(e)
-                    return
-
-            # Prepare the data directory ahead of the analysis.
-            _, _, slug = analysis.osmnx_query(country, city, region)
-            data_dir = DATA_DIR / slug
-            data_dir.mkdir(parents=True, exist_ok=True)
-
-            # Copy the OSM data into the data directory.
-            shutil.copy(cached_region_file, data_dir)
-            shutil.copy(cached_region_file_md5, data_dir)
 
             # Run the analysis.
             run_with.compose(

--- a/utils/cache-warmer.py
+++ b/utils/cache-warmer.py
@@ -9,6 +9,11 @@ The cache will be populated with the following items:
     - US Water blocks
     - US State speed limits
     - US City speed limits
+
+From the root of this repository run:
+```bash
+uv run python utils/cache-warmer.py
+```
 """
 
 from __future__ import annotations
@@ -18,69 +23,75 @@ import os
 import pathlib
 
 import aiohttp
-import us
+import rich
 from loguru import logger
 
+from brokenspoke_analyzer.cli import root
 from brokenspoke_analyzer.core import (
     datastore,
     file_utils,
 )
+from brokenspoke_analyzer.pyrosm.data import geofabrik
+
+# Ensure DC is considered a US state.
+# https://github.com/unitedstates/python-us/issues/67
+os.environ["DC_STATEHOOD"] = "1"
+import us
 
 
 async def main():
     """Define the main function."""
+    # Disable logging.
+    root._verbose_callback(0)
+
+    # Prepare the Rich output.
+    console = rich.get_console()
+
+    CACHE_ONLY = True
     bna_store = datastore.BNADataStore(
         pathlib.Path(file_utils.get_user_cache_dir()),
-        # datastore.CacheType.USER_CACHE,
-        datastore.CacheType.AWS_S3,
-        s3_bucket=os.getenv("BNA_CACHE_AWS_S3_BUCKET"),
+        datastore.CacheType.USER_CACHE,
     )
 
+    # Start the downloads.
     async with aiohttp.ClientSession() as session:
-        await bna_store.download_state_speed_limits(session)
-        await bna_store.download_city_speed_limits(session)
-        for fips, abbr in us.states.mapping("fips", "abbr").items():
-            logger.info(f"Downloading LODES data for {abbr} ({fips})")
-            lehd_url = (
-                f"https://lehd.ces.census.gov/data/lodes/LODES7/{abbr.lower()}/od"
-            )
-            for part in ["main", "aux"]:
-                lehd_gz = f"{abbr.lower()}_od_{part.lower()}_JT00_2019.csv.gz"
-                url = f"{lehd_url}/{lehd_gz}"
-                await bna_store.fetch_to_cache(session, url, lehd_gz)
-            logger.info(f"Downloading census data for {abbr} ({fips})")
-            tabblk2010_zip = f"tabblock2010_{fips}_pophu.zip"
-            url = (
-                f"https://www2.census.gov/geo/tiger/TIGER2010BLKPOPHU/{tabblk2010_zip}"
-            )
-            await bna_store.fetch_to_cache(session, url, tabblk2010_zip)
+        # Download the single files first.
+        console.log("Downloading state speed limits")
+        await bna_store.download_state_speed_limits(session, cache_only=CACHE_ONLY)
+        console.log("Downloading city speed limits")
+        await bna_store.download_city_speed_limits(session, cache_only=CACHE_ONLY)
 
+        # Download the state-specific files.
+        for i, (fips, abbr) in enumerate(us.states.mapping("fips", "abbr").items()):
+            # Skip US territories.
+            # They are part of the US but we don't have any data for them.
+            if fips in {"60", "66", "69", "72", "78"}:
+                continue
+            with console.status(
+                f"[{i + 1}/{len(us.states.STATES)}] Processing {abbr} ({fips})"
+            ):
+                console.log(f"Downloading US Census data for {abbr} ({fips})")
+                await bna_store.download_2020_census_blocks(session, fips)
+                console.log(f"Downloading LODES data for {abbr} ({fips})")
+                await bna_store.download_lodes_data(
+                    session, abbr, cache_only=CACHE_ONLY
+                )
 
-async def main_2020():
-    """Define the main function for  caching the 2020 files."""
-    bna_store = datastore.BNADataStore(
-        pathlib.Path(file_utils.get_user_cache_dir()),
-        # datastore.CacheType.USER_CACHE,
-        datastore.CacheType.AWS_S3,
-        s3_bucket=os.getenv("BNA_CACHE_AWS_S3_BUCKET"),
-    )
+        # Download the OSM data for the specified regions.
+        osm_regions = []
+        # Add the US states.
+        osm_regions.extend(geofabrik.USA()._sources.keys())
 
-    async with aiohttp.ClientSession() as session:
-        for fips, abbr in us.states.mapping("fips", "abbr").items():
-            logger.info(f"Downloading LODES data for {abbr} ({fips})")
-            lehd_url = (
-                f"https://lehd.ces.census.gov/data/lodes/LODES8/{abbr.lower()}/od"
-            )
-            for part in ["main", "aux"]:
-                lehd_gz = f"{abbr.lower()}_od_{part.lower()}_JT00_2022.csv.gz"
-                url = f"{lehd_url}/{lehd_gz}"
-                await bna_store.fetch_to_cache(session, url, lehd_gz)
-
-            logger.info(f"Downloading census data for {abbr} ({fips})")
-            tabblk2020_zip = f"tl_2020_{fips}_tabblock20.zip"
-            url = f"https://www2.census.gov/geo/tiger/TIGER2020/TABBLOCK20/{tabblk2020_zip}"
-            await bna_store.fetch_to_cache(session, url, tabblk2020_zip)
+        # Start the downloads.
+        for i, region in enumerate(osm_regions):
+            with console.status(
+                f"[{i + 1}/{len(osm_regions)}] Processing OSM {region}"
+            ):
+                console.log(f"Downloading OSM data for {region}")
+                await bna_store.download_osm_data(
+                    session, region, cache_only=CACHE_ONLY
+                )
 
 
 if __name__ == "__main__":
-    asyncio.run(main_2020())
+    asyncio.run(main())

--- a/uv.lock
+++ b/uv.lock
@@ -245,30 +245,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.82"
+version = "1.42.91"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/91/7aa096d8dd134cea02faca5594bb09f90dde403b342bfb0d63c64357039f/boto3-1.42.82.tar.gz", hash = "sha256:6df9ca0f5047c6afe6bd42244d8e059cde69e2cdb719ebd68d52c7d7beb529b2", size = 112768, upload-time = "2026-04-02T19:40:08.787Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/c0/98b8cec7ca22dde776df48c58940ae1abc425593959b7226e270760d726f/boto3-1.42.91.tar.gz", hash = "sha256:03d70532b17f7f84df37ca7e8c21553280454dea53ae12b15d1cfef9b16fcb8a", size = 113181, upload-time = "2026-04-17T19:31:06.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/ec/f55dd9fedc4948d68e8d7880019e853c76d0fbf06057e894f10e95e910dd/boto3-1.42.82-py3-none-any.whl", hash = "sha256:804341c8197c556e8e7ceb82388ee120f319a4efbb9dc368f6059760a11cfc7d", size = 140556, upload-time = "2026-04-02T19:40:07.225Z" },
+    { url = "https://files.pythonhosted.org/packages/02/29/faba6521257c34085cc9b439ef98235b581772580f417fa3629728007270/boto3-1.42.91-py3-none-any.whl", hash = "sha256:04e72071cde022951ce7f81bd9933c90095ab8923e8ced61c8dacfe9edac0f5c", size = 140553, upload-time = "2026-04-17T19:31:02.57Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.82"
+version = "1.42.91"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/b8/a9a58298f44fe0199b570204b37117e454b58a33bb1f3fe0b953338f83f3/botocore-1.42.82.tar.gz", hash = "sha256:a2bfe8537e95462ec06a46cc29c327f84746722bb4ce106491bfd3af8075ceed", size = 15140756, upload-time = "2026-04-02T19:39:56.59Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/bc/a4b7c46471c2e789ad8c4c7acfd7f302fdb481d93ff870f441249b924ae6/botocore-1.42.91.tar.gz", hash = "sha256:d252e27bc454afdbf5ed3dc617aa423f2c855c081e98b7963093399483ecc698", size = 15213010, upload-time = "2026-04-17T19:30:50.793Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/c1/28e7af5579a9869f6326b5eb0a3c705d3ccdb66a27e2b5c0bdaed12fa55e/botocore-1.42.82-py3-none-any.whl", hash = "sha256:824dbb58c99d894f193ed1dd75cf59650e25c1b5adb9d3a66b39fdede46f259b", size = 14817051, upload-time = "2026-04-02T19:39:53.498Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/fc/24cc0a47c824f13933e210e9ad034b4fba22f7185b8d904c0fbf5a3b2be8/botocore-1.42.91-py3-none-any.whl", hash = "sha256:7a28c3cc6bfab5724ad18899d52402b776a0de7d87fa20c3c5270bcaaf199ce8", size = 14897344, upload-time = "2026-04-17T19:30:44.245Z" },
 ]
 
 [[package]]
@@ -321,6 +321,7 @@ dependencies = [
     { name = "tenacity" },
     { name = "typer" },
     { name = "us" },
+    { name = "yarl" },
 ]
 
 [package.dev-dependencies]
@@ -330,7 +331,6 @@ dev = [
     { name = "isort" },
     { name = "jupyterlab" },
     { name = "minijinja" },
-    { name = "mypy" },
     { name = "myst-parser" },
     { name = "pandas-stubs" },
     { name = "pytest" },
@@ -346,6 +346,7 @@ dev = [
     { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-copybutton" },
     { name = "sqlfluff" },
+    { name = "ty" },
     { name = "types-beautifulsoup4" },
     { name = "types-boto3" },
     { name = "types-colorama" },
@@ -361,20 +362,21 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.5,<4" },
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
-    { name = "boto3", specifier = ">=1.42.82,<2" },
+    { name = "boto3", specifier = ">=1.42.88,<2" },
     { name = "geopandas", specifier = ">=1.1.3,<2" },
     { name = "loguru", specifier = ">=0.7.3,<0.8" },
-    { name = "obstore", specifier = ">=0.9.2" },
+    { name = "obstore", specifier = ">=0.9.3" },
     { name = "osmnx", specifier = ">=2.1.0,<3" },
-    { name = "platformdirs", specifier = ">=4.9.4" },
+    { name = "platformdirs", specifier = ">=4.9.6" },
     { name = "pygris", specifier = ">=0.2.1" },
     { name = "python-dotenv", specifier = ">=1.2.2,<2" },
     { name = "python-slugify", specifier = ">=8.0.4,<9" },
-    { name = "rich", specifier = ">=14.3.3,<15" },
+    { name = "rich", specifier = ">=15.0.0,<16" },
     { name = "sqlalchemy", extras = ["asyncio", "postgresql-psycopg"], specifier = ">=2.0.49,<3" },
     { name = "tenacity", specifier = ">=9.1.4,<10" },
     { name = "typer", specifier = ">=0.24.1,<0.25" },
     { name = "us", specifier = ">=3.2.0,<4" },
+    { name = "yarl", specifier = ">=1.23.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -384,30 +386,30 @@ dev = [
     { name = "isort", specifier = ">=8.0.1,<9" },
     { name = "jupyterlab", specifier = ">=4.5.6,<5" },
     { name = "minijinja", specifier = ">=2.19.0" },
-    { name = "mypy", specifier = ">=1.20.0,<2" },
     { name = "myst-parser", specifier = ">=5.0.0,<6" },
     { name = "pandas-stubs", specifier = ">=3.0.0.260204,<4" },
-    { name = "pytest", specifier = ">=9.0.1,<10" },
+    { name = "pytest", specifier = ">=9.0.3,<10" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0,<8" },
     { name = "pytest-mock", specifier = ">=3.15.1,<4" },
     { name = "pytest-rerunfailures", specifier = "~=16.1" },
     { name = "pytest-socket", specifier = ">=0.7.0,<0.8" },
     { name = "pytest-xdist", specifier = ">=3.8.0,<4" },
-    { name = "ruff", specifier = ">=0.15.9" },
+    { name = "ruff", specifier = ">=0.15.10" },
     { name = "sphinx", specifier = ">=9.1.0,<10" },
     { name = "sphinx-autobuild", specifier = ">=2025.8.25,<2026" },
-    { name = "sphinx-autodoc-typehints", specifier = ">=3.9.11,<4" },
+    { name = "sphinx-autodoc-typehints", specifier = ">=3.10.0,<4" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2,<0.6" },
     { name = "sqlfluff", specifier = ">=4.1.0,<5" },
+    { name = "ty", specifier = ">=0.0.29" },
     { name = "types-beautifulsoup4", specifier = ">=4.12.0.20250516" },
-    { name = "types-boto3", specifier = ">=1.42.78" },
-    { name = "types-colorama", specifier = ">=0.4.15.20250801,<0.5" },
-    { name = "types-decorator", specifier = ">=5.2.0.20251101,<6" },
-    { name = "types-jsonschema", specifier = ">=4.26.0.20260402,<5" },
-    { name = "types-pygments", specifier = ">=2.19.0.20260402,<3" },
+    { name = "types-boto3", specifier = ">=1.42.91" },
+    { name = "types-colorama", specifier = ">=0.4.15.20260408,<0.5" },
+    { name = "types-decorator", specifier = ">=5.2.0.20260408,<6" },
+    { name = "types-jsonschema", specifier = ">=4.26.0.20260408,<5" },
+    { name = "types-pygments", specifier = ">=2.20.0.20260408,<3" },
     { name = "types-python-slugify", specifier = ">=8.0.2.20240310,<9" },
-    { name = "types-six", specifier = ">=1.17.0.20251009,<2" },
+    { name = "types-six", specifier = ">=1.17.0.20260408,<2" },
     { name = "xdoctest", specifier = ">=1.3.2,<2" },
 ]
 
@@ -1174,27 +1176,6 @@ wheels = [
 ]
 
 [[package]]
-name = "librt"
-version = "0.8.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/56/9c/b4b0c54d84da4a94b37bd44151e46d5e583c9534c7e02250b961b1b6d8a8/librt-0.8.1.tar.gz", hash = "sha256:be46a14693955b3bd96014ccbdb8339ee8c9346fbe11c1b78901b55125f14c73", size = 177471, upload-time = "2026-02-17T16:13:06.101Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/3c/f614c8e4eaac7cbf2bbdf9528790b21d89e277ee20d57dc6e559c626105f/librt-0.8.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7e6bad1cd94f6764e1e21950542f818a09316645337fd5ab9a7acc45d99a8f35", size = 66529, upload-time = "2026-02-17T16:11:57.809Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/96/5836544a45100ae411eda07d29e3d99448e5258b6e9c8059deb92945f5c2/librt-0.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cf450f498c30af55551ba4f66b9123b7185362ec8b625a773b3d39aa1a717583", size = 68669, upload-time = "2026-02-17T16:11:58.843Z" },
-    { url = "https://files.pythonhosted.org/packages/06/53/f0b992b57af6d5531bf4677d75c44f095f2366a1741fb695ee462ae04b05/librt-0.8.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:eca45e982fa074090057132e30585a7e8674e9e885d402eae85633e9f449ce6c", size = 199279, upload-time = "2026-02-17T16:11:59.862Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/ad/4848cc16e268d14280d8168aee4f31cea92bbd2b79ce33d3e166f2b4e4fc/librt-0.8.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c3811485fccfda840861905b8c70bba5ec094e02825598bb9d4ca3936857a04", size = 210288, upload-time = "2026-02-17T16:12:00.954Z" },
-    { url = "https://files.pythonhosted.org/packages/52/05/27fdc2e95de26273d83b96742d8d3b7345f2ea2bdbd2405cc504644f2096/librt-0.8.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e4af413908f77294605e28cfd98063f54b2c790561383971d2f52d113d9c363", size = 224809, upload-time = "2026-02-17T16:12:02.108Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/d0/78200a45ba3240cb042bc597d6f2accba9193a2c57d0356268cbbe2d0925/librt-0.8.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5212a5bd7fae98dae95710032902edcd2ec4dc994e883294f75c857b83f9aba0", size = 218075, upload-time = "2026-02-17T16:12:03.631Z" },
-    { url = "https://files.pythonhosted.org/packages/af/72/a210839fa74c90474897124c064ffca07f8d4b347b6574d309686aae7ca6/librt-0.8.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e692aa2d1d604e6ca12d35e51fdc36f4cda6345e28e36374579f7ef3611b3012", size = 225486, upload-time = "2026-02-17T16:12:04.725Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/c1/a03cc63722339ddbf087485f253493e2b013039f5b707e8e6016141130fa/librt-0.8.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4be2a5c926b9770c9e08e717f05737a269b9d0ebc5d2f0060f0fe3fe9ce47acb", size = 218219, upload-time = "2026-02-17T16:12:05.828Z" },
-    { url = "https://files.pythonhosted.org/packages/58/f5/fff6108af0acf941c6f274a946aea0e484bd10cd2dc37610287ce49388c5/librt-0.8.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fd1a720332ea335ceb544cf0a03f81df92abd4bb887679fd1e460976b0e6214b", size = 218750, upload-time = "2026-02-17T16:12:07.09Z" },
-    { url = "https://files.pythonhosted.org/packages/71/67/5a387bfef30ec1e4b4f30562c8586566faf87e47d696768c19feb49e3646/librt-0.8.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2af9e01e0ef80d95ae3c720be101227edae5f2fe7e3dc63d8857fadfc5a1d", size = 241624, upload-time = "2026-02-17T16:12:08.43Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/be/24f8502db11d405232ac1162eb98069ca49c3306c1d75c6ccc61d9af8789/librt-0.8.1-cp313-cp313-win32.whl", hash = "sha256:086a32dbb71336627e78cc1d6ee305a68d038ef7d4c39aaff41ae8c9aa46e91a", size = 54969, upload-time = "2026-02-17T16:12:09.633Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/73/c9fdf6cb2a529c1a092ce769a12d88c8cca991194dfe641b6af12fa964d2/librt-0.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:e11769a1dbda4da7b00a76cfffa67aa47cfa66921d2724539eee4b9ede780b79", size = 62000, upload-time = "2026-02-17T16:12:10.632Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/97/68f80ca3ac4924f250cdfa6e20142a803e5e50fca96ef5148c52ee8c10ea/librt-0.8.1-cp313-cp313-win_arm64.whl", hash = "sha256:924817ab3141aca17893386ee13261f1d100d1ef410d70afe4389f2359fea4f0", size = 52495, upload-time = "2026-02-17T16:12:11.633Z" },
-]
-
-[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1354,37 +1335,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy"
-version = "1.20.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "mypy-extensions" },
-    { name = "pathspec" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/b0089fe7fef0a994ae5ee07029ced0526082c6cfaaa4c10d40a10e33b097/mypy-1.20.0.tar.gz", hash = "sha256:eb96c84efcc33f0b5e0e04beacf00129dd963b67226b01c00b9dfc8affb464c3", size = 3815028, upload-time = "2026-03-31T16:55:14.959Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/a7/f64ea7bd592fa431cb597418b6dec4a47f7d0c36325fec7ac67bc8402b94/mypy-1.20.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b20c8b0fd5877abdf402e79a3af987053de07e6fb208c18df6659f708b535134", size = 14485344, upload-time = "2026-03-31T16:49:16.78Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/72/8927d84cfc90c6abea6e96663576e2e417589347eb538749a464c4c218a0/mypy-1.20.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:367e5c993ba34d5054d11937d0485ad6dfc60ba760fa326c01090fc256adf15c", size = 13327400, upload-time = "2026-03-31T16:53:08.02Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/4a/11ab99f9afa41aa350178d24a7d2da17043228ea10f6456523f64b5a6cf6/mypy-1.20.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f799d9db89fc00446f03281f84a221e50018fc40113a3ba9864b132895619ebe", size = 13706384, upload-time = "2026-03-31T16:52:28.577Z" },
-    { url = "https://files.pythonhosted.org/packages/42/79/694ca73979cfb3535ebfe78733844cd5aff2e63304f59bf90585110d975a/mypy-1.20.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:555658c611099455b2da507582ea20d2043dfdfe7f5ad0add472b1c6238b433f", size = 14700378, upload-time = "2026-03-31T16:48:45.527Z" },
-    { url = "https://files.pythonhosted.org/packages/84/24/a022ccab3a46e3d2cdf2e0e260648633640eb396c7e75d5a42818a8d3971/mypy-1.20.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:efe8d70949c3023698c3fca1e94527e7e790a361ab8116f90d11221421cd8726", size = 14932170, upload-time = "2026-03-31T16:49:36.038Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/9b/549228d88f574d04117e736f55958bd4908f980f9f5700a07aeb85df005b/mypy-1.20.0-cp313-cp313-win_amd64.whl", hash = "sha256:f49590891d2c2f8a9de15614e32e459a794bcba84693c2394291a2038bbaaa69", size = 10888526, upload-time = "2026-03-31T16:50:59.827Z" },
-    { url = "https://files.pythonhosted.org/packages/91/17/15095c0e54a8bc04d22d4ff06b2139d5f142c2e87520b4e39010c4862771/mypy-1.20.0-cp313-cp313-win_arm64.whl", hash = "sha256:76a70bf840495729be47510856b978f1b0ec7d08f257ca38c9d932720bf6b43e", size = 9816456, upload-time = "2026-03-31T16:49:59.537Z" },
-    { url = "https://files.pythonhosted.org/packages/21/66/4d734961ce167f0fd8380769b3b7c06dbdd6ff54c2190f3f2ecd22528158/mypy-1.20.0-py3-none-any.whl", hash = "sha256:a6e0641147cbfa7e4e94efdb95c2dab1aff8cfc159ded13e07f308ddccc8c48e", size = 2636365, upload-time = "2026-03-31T16:51:44.911Z" },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
-]
-
-[[package]]
 name = "myst-parser"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1518,36 +1468,36 @@ wheels = [
 
 [[package]]
 name = "obstore"
-version = "0.9.2"
+version = "0.9.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/18/cab734edaeb495a861cfbdced9fecdc0866ed1a85aa5a9202ec77cf4723e/obstore-0.9.2.tar.gz", hash = "sha256:7ef94323127a971c9dea2484109d6c706eb2b2594a2df13c2dd0a6d21a9a69ae", size = 123731, upload-time = "2026-03-11T19:10:18.19Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/96/b4e0d466715daec9e221cccb8ac57dc91ba08830a68d7ed5a2729ab21a32/obstore-0.9.3.tar.gz", hash = "sha256:0f56e7efd53c22e7eaf14ccce931c678b01a016ceb2226cd4bb01c741a58f5a2", size = 124143, upload-time = "2026-04-15T18:16:56.812Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/d2/b98058a552849719df56d59a53f7d97e6507b37fca0399a866534800f9fa/obstore-0.9.2-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:50d9c9d6de601ad4805a5a76a1a3d731f7b899383f96ef57276f97bc35202f95", size = 4105494, upload-time = "2026-03-11T19:09:06.573Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/55/4386622b94fd028cb2298b4780d5a8e2d959fc4c71e599fb63be869aa83d/obstore-0.9.2-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:4c6dcd9b76b802a2278e1cd88ad7305caf3c3c16f800b2bf5f86a606e9e83d96", size = 3878429, upload-time = "2026-03-11T19:09:07.962Z" },
-    { url = "https://files.pythonhosted.org/packages/91/8d/0bfad11f1ee5fb1fbdb7833607212ad2586dbd1824b30cf328af63fe92fc/obstore-0.9.2-cp311-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8d46e629beb47565fa67b6ef05919434258d72ef848efa340f911af5de2536da", size = 4041157, upload-time = "2026-03-11T19:09:09.278Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/98/bfde825f61a8b2541be9185cd6a4ddbb820de94c79750edc32f9f9dfb795/obstore-0.9.2-cp311-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:350d8cc1cd9564369291396e160ebfa133d705ec349d8c0d444a39158d6ef3e7", size = 4144757, upload-time = "2026-03-11T19:09:10.938Z" },
-    { url = "https://files.pythonhosted.org/packages/19/35/1c101f6660ef91e5280c824677d8b5ab11ee25ed52e59b075cd795a86e69/obstore-0.9.2-cp311-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dddd38c9f98fd8eaf11a9805464f0bec7e57d8e04a5e0b0cb17582ec58d2fe41", size = 4427897, upload-time = "2026-03-11T19:09:12.137Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/eb/a9bdb64474d4e0ab4e4c0105c959090d6bd7ce38d4a945cae3679ead8c52/obstore-0.9.2-cp311-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ca872e88e5c719faf1581632e348a6b01331b4f838d7ac29aff226107088dc35", size = 4336227, upload-time = "2026-03-11T19:09:13.822Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/ec/e6d39aa311afec2241adb6f2067d7d6ca2eb4e0aab5a95c47796edadd524/obstore-0.9.2-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ee61ac2af5c32c5282fc13b9eba7ffa332f268cb65bc29134ad8ac45e069871", size = 4229010, upload-time = "2026-03-11T19:09:15.503Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/fb/a24fd972b66b2d83829e2e89ccf236a759a82f881f909bf4fbe0b6c398ae/obstore-0.9.2-cp311-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:2f430cf8af76985e7ebb8d5f20c8ccef858c608103af6ea95c870f5380cd62f7", size = 4103835, upload-time = "2026-03-11T19:09:16.729Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/d4/c8cc60c8afc597712bf6c5059d629e050de521d901dad0f554b268c2d77f/obstore-0.9.2-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1df403f80feef7ac483ed66a2a5a964a469f3756ded533935640c4baf986dd49", size = 4292174, upload-time = "2026-03-11T19:09:18.461Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/80/dcf8f31814f25c390aa5501a95b78b9f6456d30cd4625109c2a6a5105ad1/obstore-0.9.2-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c20f62b7c2f57c6f449215c36af4a8d502082ced2185c0b28f07a5e7c9698181", size = 4276266, upload-time = "2026-03-11T19:09:19.787Z" },
-    { url = "https://files.pythonhosted.org/packages/16/71/5f5369fba652c5f83b44381d9e7a3cfe00793301d01802059b52b8663f2c/obstore-0.9.2-cp311-abi3-musllinux_1_2_i686.whl", hash = "sha256:c296e7d60ee132babb7fd01eab946396fa28eb0d88264b9e60320922174e6010", size = 4264118, upload-time = "2026-03-11T19:09:21.081Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/50/a5bd1948f2b2efb1039852542829a33a198be0586da7d4247996d3f15d26/obstore-0.9.2-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:76f274a170731a4461d0fe3eefde38f3bdaf346011ae020c94a0bd18bfd3c4bc", size = 4446876, upload-time = "2026-03-11T19:09:22.401Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/d6/bcc266e391403163ed12dd8cab53012f4db8f5020fb49e3b0a505d7a1bba/obstore-0.9.2-cp311-abi3-win_amd64.whl", hash = "sha256:f644fef2a91973b6c055623692524baf830abb1f8bb3ad348611f0e25224e160", size = 4190639, upload-time = "2026-03-11T19:09:23.637Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/da/ea7c5095cf15c026819958f74d3ab7b69aff7ce5bf74188e5df5bba4c252/obstore-0.9.2-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7161a977e94a94dfd2c4ef66846371bdff46bb8b5f9b91dc29c912deb88a5bb2", size = 4087051, upload-time = "2026-03-11T19:09:24.944Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/9f/16d6f41ab87e75a6400959a4708343eaca782b78a5f9de7846c70e2b1381/obstore-0.9.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e3a31fbd68bbe7e061272420337d5ccaf2df7927c2b44ff768531dda02196746", size = 3869338, upload-time = "2026-03-11T19:09:26.404Z" },
-    { url = "https://files.pythonhosted.org/packages/99/61/5f13cc91b054d8c93db77e9113ca4924c4320e988284840c8a98238709e6/obstore-0.9.2-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:928da0d131ea33d0b88aa8c3a0dd3f7423261e0c9495444cc14ce0cf62808558", size = 4037703, upload-time = "2026-03-11T19:09:27.743Z" },
-    { url = "https://files.pythonhosted.org/packages/58/a2/669620821881559819b8911c4820defa3ffc30a9e49e9d5aca05bd57da45/obstore-0.9.2-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:79667de1f0c7eed64b658b3e696bb0565fba4069f6134db502bf4f5f5835aeee", size = 4135488, upload-time = "2026-03-11T19:09:29.232Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/12/019e523e97415b4fcfc35b230b270d452fdf5578a7612034c8043c8f2cbf/obstore-0.9.2-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7318253bc8d03b64473150dad31e611f5bd70a3cc945e3e1d6ac59a901f397c0", size = 4412922, upload-time = "2026-03-11T19:09:30.462Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/52/d4a8c1bf588a10bfd17a5a11ebc6af834850fe174a0369648d534a2acb81/obstore-0.9.2-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:133507229632fde08bc202ca2c81119b2314662dab7a96f8348e97f8e97ae36a", size = 4337193, upload-time = "2026-03-11T19:09:31.773Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/59/46c1bdaeae2904bb1edddbfc78e35cb0521ab7c58fe92b147a981873fcdc/obstore-0.9.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1c73f208abcddcd3edb7a739d5cac777bdb6fac12a358c9b251654ec7df7866", size = 4221641, upload-time = "2026-03-11T19:09:33.067Z" },
-    { url = "https://files.pythonhosted.org/packages/44/9c/b0203594666d11da31e4a7f25ace0718cb1591792e3c1de5225fbd7c8246/obstore-0.9.2-cp313-cp313t-manylinux_2_24_aarch64.whl", hash = "sha256:857b2e7d78c8fb36dcb7c6f1fa89401429667195186ced746a500e54a6aaecdb", size = 4103500, upload-time = "2026-03-11T19:09:34.687Z" },
-    { url = "https://files.pythonhosted.org/packages/95/bc/b215712ef24a21247d6e8a4049a76d95e2dca517b8b24efb496600c333c7/obstore-0.9.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:24c24fdba5080524ce79b36782a11563ea40d9ae5aa26bb6b81a6d089184e4eb", size = 4290492, upload-time = "2026-03-11T19:09:35.936Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/28/5aa0ecdc6c01b6e020f1ff8efcca35493e0c6091a0b72ec1bbb16b5b18a8/obstore-0.9.2-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:778785266aaaf3a73d44ee15e33b72c7ecf0585efeaf8745a1889cc02930ae59", size = 4272220, upload-time = "2026-03-11T19:09:37.223Z" },
-    { url = "https://files.pythonhosted.org/packages/06/65/c47b0f972bc7acd64385a964dfbc2efc7361207f490b4d16da789da26fd5/obstore-0.9.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:305c415fdb2230a1e096f6f290cf524d030329ad5c5e1c9c41f121e7d2fb27d7", size = 4256524, upload-time = "2026-03-11T19:09:38.592Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/1d/9f826fd49cd17cdbc8d2a7a75698d1cc9d731ca98d645f1ca9366ac93781/obstore-0.9.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:1a544aad84ae774fac339c686f8a4d7b187c4927b6e33ebb9758c58991d4f27f", size = 4440986, upload-time = "2026-03-11T19:09:40.231Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/24/0af1af62239c539975b6c9095428f7597e8f5f9617e897e58dbf7b63f1c5/obstore-0.9.2-cp313-cp313t-win_amd64.whl", hash = "sha256:52da6bd719c4962fdfb3c7504e790a89a9b5d27703ee872db01e2075162706fd", size = 4175182, upload-time = "2026-03-11T19:09:41.617Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/202a30127786169e74516ae700de8f153c430d349985bf6d09b33ab7f481/obstore-0.9.3-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e56bd948c87e0b16211ea0363913529c1cda67d9ada809c28e70a9b22c385433", size = 4112171, upload-time = "2026-04-15T18:15:09.478Z" },
+    { url = "https://files.pythonhosted.org/packages/df/8e/fc4995a82b53cdd8e61f5ebfe5007deeeda4f0746b0e46e1dbbd293d9d3d/obstore-0.9.3-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b65c3d17ff6fa7a239b99df05e6f2badb1852a1cc56ebcd24f9347d88b5cc629", size = 3880522, upload-time = "2026-04-15T18:15:11.744Z" },
+    { url = "https://files.pythonhosted.org/packages/86/82/5f6c3ff5b25e6bd0b97c6d5459b91edcbc4ab71e66a2df1b9a6884a8a4bc/obstore-0.9.3-cp311-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7178850a492a3bd534bf6d178d20aee4a171e6b4a4fead46f9879a630db06353", size = 4042745, upload-time = "2026-04-15T18:15:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b1/5df6a6b2f1a8039b3dc06e9a0d990fe26471f153529a8e92dad4167f505a/obstore-0.9.3-cp311-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5fdc75d11d4f17dd79fe47bb7576dd404675d52f99e0d998319f4bf032541171", size = 4145646, upload-time = "2026-04-15T18:15:15.829Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3a/a238ad9e1c4f3aba8a7acff04eba7d7e143aa07f7a26435acf5655372953/obstore-0.9.3-cp311-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1943511b022ce49010059b4b274f1608daf041827e9a8e0ae2311c70fcea921b", size = 4427486, upload-time = "2026-04-15T18:15:17.635Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/be/adffdbec3edb4cf2bea2f856ebf14efc0e398843a477823040c95a39c754/obstore-0.9.3-cp311-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:35c4ed947b1cb5da6d8a8af8d2378b038dab34deb86e679c940a8a09f2ad72a4", size = 4340837, upload-time = "2026-04-15T18:15:19.711Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/cf/92593c3981e38e9f682d858aff251f6731517d682a9b389cb1e2c94ed6a4/obstore-0.9.3-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab427bec57b8b5084eccd78d7592cf28860a1cf631bd0e0b8c0e0b793efdc033", size = 4231679, upload-time = "2026-04-15T18:15:21.473Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/8b/920f726117180e57c51bf6bc503f286782a3bbb6fb8f70ed9bff4f674796/obstore-0.9.3-cp311-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:48f58c44c9a5c7b82346fe5e3469bae3109c8b168c1c096c41b80a9f0bc8d5a6", size = 4105350, upload-time = "2026-04-15T18:15:23.566Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5c/6abd29ae02f64f677a67cab6ee5492d14f004b483bafbf397c3ddef4f4bf/obstore-0.9.3-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:591db6375f90a7528f902d3cff8738d93219d6162d517e4d464bd333133daa1d", size = 4296104, upload-time = "2026-04-15T18:15:25.388Z" },
+    { url = "https://files.pythonhosted.org/packages/21/92/a1eacdf5bf0ca2d2d7fc6d6430e1f305782abaa0409fe120fcfc3083dea4/obstore-0.9.3-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:e42c3caf9f77a2a5aaddfd6a2356c3ad317884f188cfec5b000c48c21362af79", size = 4278210, upload-time = "2026-04-15T18:15:27.43Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c6/8e62cab73552f5491f01bffbb279b7d25ec148fb89ca4ad4192ac00c6d95/obstore-0.9.3-cp311-abi3-musllinux_1_2_i686.whl", hash = "sha256:bb509ea1fec9dcee996151f2c5d6664b1516da12675d2c27583ef9fff81c43ec", size = 4266039, upload-time = "2026-04-15T18:15:29.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3f/36b1823574277d3a494b7280883a0d78ed46e71d3e8e4de2b8135b15792a/obstore-0.9.3-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6eec5a7a917ec6a5148d4dd6a0e53ce87949c520de96b1822bbbc4aa79b65610", size = 4451602, upload-time = "2026-04-15T18:15:31.468Z" },
+    { url = "https://files.pythonhosted.org/packages/20/4c/8f4650d2e29472998bbcbfb1f0a67e865fea419108faa43f5d180bdb166a/obstore-0.9.3-cp311-abi3-win_amd64.whl", hash = "sha256:87a1d5db9804df06f0ed5cd25b209c527fc2ec54a91c56ae6ff62d27db680b92", size = 4190181, upload-time = "2026-04-15T18:15:33.235Z" },
+    { url = "https://files.pythonhosted.org/packages/22/9f/8df3b10646a3b90c318f85f8e89feca337c6cf56cb50f003e03124186dd2/obstore-0.9.3-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:d738d976a15cca90fb6a900c4f546544644b38a559bb99f6372030bb80e058d5", size = 4084824, upload-time = "2026-04-15T18:15:35.038Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ce/e5729f8504e48ab88586138a0311ae7800a2f61a3fc989444ee29a1dbdb6/obstore-0.9.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:663ed5b534d3896e703725d2b4f11959fbbb3e499b39e7f2fb9044aad658c568", size = 3867311, upload-time = "2026-04-15T18:15:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/30/c96619b6faf1337edd0ba82bf06cbf6d20124152d9848a20bbe4ec8da046/obstore-0.9.3-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5c3d84f21424dbb9d7acd0111d3f281e61ca0f8a21f7b7f2e5599d515fff5b02", size = 4036006, upload-time = "2026-04-15T18:15:39.071Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ab/48e5caf2bac13deba9d4e87dda28850f68b39b69a0431e5254200bfed786/obstore-0.9.3-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d535037d5c4240a849716b69e98aa7e7e5cea1b116558ede08a9962f501c23b3", size = 4135380, upload-time = "2026-04-15T18:15:41.783Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d4/11f6a74df6d0b891be9538129c61cee50518835face031d0138a2505e371/obstore-0.9.3-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:71cdbebbcb78f63ffe4042e86e1ad41e723245bad42cf79b4c750592cb01aa57", size = 4414425, upload-time = "2026-04-15T18:15:43.586Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c3/d299c174875490bbe9110d68887acbf4e197dd13becda75f1b8e13033f46/obstore-0.9.3-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d196a009870151d8c1bf8a550e3ce0c15c6a48af9bb36bb8954e70e52136863d", size = 4338358, upload-time = "2026-04-15T18:15:45.898Z" },
+    { url = "https://files.pythonhosted.org/packages/01/ab/29b55e1536ea0891062d0f2109f5c81804cb36976590418700bf8ec287b9/obstore-0.9.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da32f949a21dfa15739ce6286572a67ce167b827e0a28cbcbb956c25d29162fa", size = 4220536, upload-time = "2026-04-15T18:15:47.822Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/08/3ee0302ccb106c82600e9e0c1985c426f9906116ef68ecb0a0547ad0e728/obstore-0.9.3-cp313-cp313t-manylinux_2_24_aarch64.whl", hash = "sha256:a97b7ba1211c39ec58821c52a8719fde710e17ee17c40067e360f45c1e444a0b", size = 4102754, upload-time = "2026-04-15T18:15:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/17/04/fa33f40d8f96ecce24bcd1c92989a95885c78509e587748960b0299df696/obstore-0.9.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f5051b250080f739b53ff0c09a16b369206aa0aa904449cd8eadae8f51b03d0f", size = 4290696, upload-time = "2026-04-15T18:15:52.003Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/43/30e1d06f1c037a2e032d016ba381950ba8589432f012b88c3866af00f6ea/obstore-0.9.3-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:9a7251b2ffbb945cf19daf05c074850a79661ee667ba1e95cb53891cb706b9aa", size = 4272490, upload-time = "2026-04-15T18:15:53.969Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d6/2b4fe6979a4f2b0c53b0caea2fa7ceaf1494a0662cd8fa1d127fdc3d659d/obstore-0.9.3-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:b8db25033f71e17e996ca05043118e64cf2067190081912dee85cb4c0ab192e5", size = 4254455, upload-time = "2026-04-15T18:15:56.313Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/6974c786022f5339243d44a10f53708a8a17c8b7f7b5ad7cf7d9236c9e36/obstore-0.9.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e5f07ca479133dd1768b763cddcd1f3990a22ca4f2f071f5fd77d2bdf7d2baec", size = 4440612, upload-time = "2026-04-15T18:15:58.219Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/72/9efbd4331a7c58b520a15bf11086ef483c2f86859fa08788741442bb0b76/obstore-0.9.3-cp313-cp313t-win_amd64.whl", hash = "sha256:48e4debe9e0f2efc89208b95cc72dbc666debafd453fe6e9e71e6a24260fb4f6", size = 4177664, upload-time = "2026-04-15T18:16:00.642Z" },
 ]
 
 [[package]]
@@ -1665,11 +1615,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.9.4"
+version = "4.9.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
 ]
 
 [[package]]
@@ -1870,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1879,9 +1829,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -2175,15 +2125,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "14.3.3"
+version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]
@@ -2234,27 +2184,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.9"
+version = "0.15.11"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/97/e9f1ca355108ef7194e38c812ef40ba98c7208f47b13ad78d023caa583da/ruff-0.15.9.tar.gz", hash = "sha256:29cbb1255a9797903f6dde5ba0188c707907ff44a9006eb273b5a17bfa0739a2", size = 4617361, upload-time = "2026-04-02T18:17:20.829Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/1f/9cdfd0ac4b9d1e5a6cf09bedabdf0b56306ab5e333c85c87281273e7b041/ruff-0.15.9-py3-none-linux_armv6l.whl", hash = "sha256:6efbe303983441c51975c243e26dff328aca11f94b70992f35b093c2e71801e1", size = 10511206, upload-time = "2026-04-02T18:16:41.574Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/f6/32bfe3e9c136b35f02e489778d94384118bb80fd92c6d92e7ccd97db12ce/ruff-0.15.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4965bac6ac9ea86772f4e23587746f0b7a395eccabb823eb8bfacc3fa06069f7", size = 10923307, upload-time = "2026-04-02T18:17:08.645Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/25/de55f52ab5535d12e7aaba1de37a84be6179fb20bddcbe71ec091b4a3243/ruff-0.15.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:eaf05aad70ca5b5a0a4b0e080df3a6b699803916d88f006efd1f5b46302daab8", size = 10316722, upload-time = "2026-04-02T18:16:44.206Z" },
-    { url = "https://files.pythonhosted.org/packages/48/11/690d75f3fd6278fe55fff7c9eb429c92d207e14b25d1cae4064a32677029/ruff-0.15.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9439a342adb8725f32f92732e2bafb6d5246bd7a5021101166b223d312e8fc59", size = 10623674, upload-time = "2026-04-02T18:16:50.951Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/ec/176f6987be248fc5404199255522f57af1b4a5a1b57727e942479fec98ad/ruff-0.15.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9c5e6faf9d97c8edc43877c3f406f47446fc48c40e1442d58cfcdaba2acea745", size = 10351516, upload-time = "2026-04-02T18:16:57.206Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/fc/51cffbd2b3f240accc380171d51446a32aa2ea43a40d4a45ada67368fbd2/ruff-0.15.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b34a9766aeec27a222373d0b055722900fbc0582b24f39661aa96f3fe6ad901", size = 11150202, upload-time = "2026-04-02T18:17:06.452Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/d4/25292a6dfc125f6b6528fe6af31f5e996e19bf73ca8e3ce6eb7fa5b95885/ruff-0.15.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:89dd695bc72ae76ff484ae54b7e8b0f6b50f49046e198355e44ea656e521fef9", size = 11988891, upload-time = "2026-04-02T18:17:18.575Z" },
-    { url = "https://files.pythonhosted.org/packages/13/e1/1eebcb885c10e19f969dcb93d8413dfee8172578709d7ee933640f5e7147/ruff-0.15.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ce187224ef1de1bd225bc9a152ac7102a6171107f026e81f317e4257052916d5", size = 11480576, upload-time = "2026-04-02T18:16:52.986Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/6b/a1548ac378a78332a4c3dcf4a134c2475a36d2a22ddfa272acd574140b50/ruff-0.15.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b0c7c341f68adb01c488c3b7d4b49aa8ea97409eae6462d860a79cf55f431b6", size = 11254525, upload-time = "2026-04-02T18:17:02.041Z" },
-    { url = "https://files.pythonhosted.org/packages/42/aa/4bb3af8e61acd9b1281db2ab77e8b2c3c5e5599bf2a29d4a942f1c62b8d6/ruff-0.15.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:55cc15eee27dc0eebdfcb0d185a6153420efbedc15eb1d38fe5e685657b0f840", size = 11204072, upload-time = "2026-04-02T18:17:13.581Z" },
-    { url = "https://files.pythonhosted.org/packages/69/48/d550dc2aa6e423ea0bcc1d0ff0699325ffe8a811e2dba156bd80750b86dc/ruff-0.15.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6537f6eed5cda688c81073d46ffdfb962a5f29ecb6f7e770b2dc920598997ed", size = 10594998, upload-time = "2026-04-02T18:16:46.369Z" },
-    { url = "https://files.pythonhosted.org/packages/63/47/321167e17f5344ed5ec6b0aa2cff64efef5f9e985af8f5622cfa6536043f/ruff-0.15.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6d3fcbca7388b066139c523bda744c822258ebdcfbba7d24410c3f454cc9af71", size = 10359769, upload-time = "2026-04-02T18:17:10.994Z" },
-    { url = "https://files.pythonhosted.org/packages/67/5e/074f00b9785d1d2c6f8c22a21e023d0c2c1817838cfca4c8243200a1fa87/ruff-0.15.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:058d8e99e1bfe79d8a0def0b481c56059ee6716214f7e425d8e737e412d69677", size = 10850236, upload-time = "2026-04-02T18:16:48.749Z" },
-    { url = "https://files.pythonhosted.org/packages/76/37/804c4135a2a2caf042925d30d5f68181bdbd4461fd0d7739da28305df593/ruff-0.15.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8e1ddb11dbd61d5983fa2d7d6370ef3eb210951e443cace19594c01c72abab4c", size = 11358343, upload-time = "2026-04-02T18:16:55.068Z" },
-    { url = "https://files.pythonhosted.org/packages/88/3d/1364fcde8656962782aa9ea93c92d98682b1ecec2f184e625a965ad3b4a6/ruff-0.15.9-py3-none-win32.whl", hash = "sha256:bde6ff36eaf72b700f32b7196088970bf8fdb2b917b7accd8c371bfc0fd573ec", size = 10583382, upload-time = "2026-04-02T18:17:04.261Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/56/5c7084299bd2cacaa07ae63a91c6f4ba66edc08bf28f356b24f6b717c799/ruff-0.15.9-py3-none-win_amd64.whl", hash = "sha256:45a70921b80e1c10cf0b734ef09421f71b5aa11d27404edc89d7e8a69505e43d", size = 11744969, upload-time = "2026-04-02T18:16:59.611Z" },
-    { url = "https://files.pythonhosted.org/packages/03/36/76704c4f312257d6dbaae3c959add2a622f63fcca9d864659ce6d8d97d3d/ruff-0.15.9-py3-none-win_arm64.whl", hash = "sha256:0694e601c028fd97dc5c6ee244675bc241aeefced7ef80cd9c6935a871078f53", size = 11005870, upload-time = "2026-04-02T18:17:15.773Z" },
+    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
+    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
+    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
 ]
 
 [[package]]
@@ -2406,14 +2356,14 @@ wheels = [
 
 [[package]]
 name = "sphinx-autodoc-typehints"
-version = "3.9.11"
+version = "3.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/e9/d29ae58dd12971d2cbb872884676a70d1a5e4719b4d82e197264cdf0431a/sphinx_autodoc_typehints-3.9.11.tar.gz", hash = "sha256:28516c916b41fa83271ee2ab9191b73807e4113d3bfb94222ac87d8d9795b6e7", size = 70261, upload-time = "2026-03-24T16:57:28.462Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/75/9a5695b3d3b848a43cfe91c7d7d3c5ab543eb3bc5c2a12ffaf5003a2a4f6/sphinx_autodoc_typehints-3.10.2.tar.gz", hash = "sha256:34db651eb14343ba16bd9c03e0f5093971f9bbd3cc6b0a1470adecd578940b9c", size = 74241, upload-time = "2026-04-15T22:09:48.87Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/e3/ff212b51c16717681792eaf18691e6b5affbbb3d4290147c457fa9127372/sphinx_autodoc_typehints-3.9.11-py3-none-any.whl", hash = "sha256:b5cbc7a56a9338021ab7a4e6aa132aa7829fa2f8b64eca927faab64cd3971b80", size = 37279, upload-time = "2026-03-24T16:57:27.147Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/0f/f1c2e2592f995d301bc06901fbb2e947cbe4889397a418309710ccc3a1db/sphinx_autodoc_typehints-3.10.2-py3-none-any.whl", hash = "sha256:2d1bcac8f62b8d0d210f6ca44b8e016e314d07cc8c30d0512cf6986a0b042b26", size = 39231, upload-time = "2026-04-15T22:09:47.413Z" },
 ]
 
 [[package]]
@@ -2671,6 +2621,30 @@ wheels = [
 ]
 
 [[package]]
+name = "ty"
+version = "0.0.31"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/cc/5ea5d3a72216c8c2bf77d83066dd4f3553532d0aacc03d4a8397dd9845e1/ty-0.0.31.tar.gz", hash = "sha256:4a4094292d9671caf3b510c7edf36991acd9c962bb5d97205374ffed9f541c45", size = 5516619, upload-time = "2026-04-15T15:47:59.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/10/ea805cbbd75d5d50792551a2b383de8521eeab0c44f38c73e12819ced65e/ty-0.0.31-py3-none-linux_armv6l.whl", hash = "sha256:761651dc17ad7bc0abfc1b04b3f0e84df263ed435d34f29760b3da739ab02d35", size = 10834749, upload-time = "2026-04-15T15:48:14.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4c/fabf951850401d24d36b21bced088a366c6827e1c37dab4523afff84c4b2/ty-0.0.31-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c529922395a07231c27488f0290651e05d27d149f7e0aa807678f1f7e9c58a5e", size = 10626012, upload-time = "2026-04-15T15:48:22.554Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b0/4a5aff88d2544f19514a59c8f693d63144aa7307fe2ee5df608333ab5460/ty-0.0.31-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5f345df2b87d747859e72c2cbc9be607ea1bbc8bc93dd32fa3d03ea091cb4fee", size = 10075790, upload-time = "2026-04-15T15:47:46.959Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/73/9d4dcad12cd4e85274014f2c0510ef93f590b2a1e5148de3a9f276098dad/ty-0.0.31-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4b207eddcfbafd376132689d3435b14efcb531289cb59cd961c6a611133bd54", size = 10590286, upload-time = "2026-04-15T15:48:06.222Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/fe40adde18692359ded174ae7ddbfac056e876eb0f43b65be74fde7f6072/ty-0.0.31-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:663778b220f357067488ce68bfc52335ccbd161549776f70dcbde6bbde82f77a", size = 10623824, upload-time = "2026-04-15T15:48:12.965Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e8/0ffa2e09b548e6daa9ebc368d68b767dc2405ca4cbeadb7ede0e2cb21059/ty-0.0.31-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3506cfe87dfade0fb2960dd4fffd4fd8089003587b3445c0a1a295c9d83764fb", size = 11156864, upload-time = "2026-04-15T15:48:08.473Z" },
+    { url = "https://files.pythonhosted.org/packages/08/e9/fd44c2075115d569593ee9473d7e2a38b750fd7e783421c95eb528c15df5/ty-0.0.31-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8b3f3d8492f08e81916026354c1d1599e9ddfa1241804141a74d5662fc710085", size = 11696401, upload-time = "2026-04-15T15:48:17.355Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/50/35aad8eadf964d23e2a4faa5b38a206aa85c78833c8ce335dddd2c34ba63/ty-0.0.31-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a97de32ee6a619393a4c495e056a1c547de7877510f3152e61345c71d774d2d0", size = 11374903, upload-time = "2026-04-15T15:47:55.893Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/37/01eccd25d23f5aaa7f7ff1a87b5b215469f6b202cf689a1812b71c1e7f6b/ty-0.0.31-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c906354ce441e342646582bc9b8f48a676f79f3d061e25de15ff870e015ca14e", size = 11206624, upload-time = "2026-04-15T15:47:51.778Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/70/baad2914cb097453f127a221f8addb2b41926098059cd773c75e6a662fc4/ty-0.0.31-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:275bb7c82afcbf89fe2dbef1b2692f2bc98451f1ee2c8eb809ddd91317822388", size = 10575089, upload-time = "2026-04-15T15:47:49.448Z" },
+    { url = "https://files.pythonhosted.org/packages/83/12/bae3a7bba2e785eb72ce00f9da70eedcb8c5e8299efecbd16e6e436abd82/ty-0.0.31-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:405da247027c6efd1e264886b6ac4a86ab3a4f09200b02e33630efe85f119e53", size = 10642315, upload-time = "2026-04-15T15:48:19.661Z" },
+    { url = "https://files.pythonhosted.org/packages/93/9e/cad04d5d839bc60355cea98c7e09d724ea65f47184def0fae8b90dc54591/ty-0.0.31-py3-none-musllinux_1_2_i686.whl", hash = "sha256:54d9835608eed196853d6643f645c50ce83bcc7fe546cdb3e210c1bcf7c58c09", size = 10834473, upload-time = "2026-04-15T15:48:02.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ba/84112d280182d37690d3d2b4018b2667e42bc281585e607015635310016a/ty-0.0.31-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5ee11be9b07e8c0c6b455ff075a0abe4f194de9476f57624db98eec9df618355", size = 11315785, upload-time = "2026-04-15T15:48:10.754Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9f/ac42dc223d7e0950e97a1854567a8b3e7fe09ad7375adbf91bfb43290482/ty-0.0.31-py3-none-win32.whl", hash = "sha256:7286587aacf3eef0956062d6492b893b02f82b0f22c5e230008e13ff0d216a8b", size = 10187657, upload-time = "2026-04-15T15:48:04.264Z" },
+    { url = "https://files.pythonhosted.org/packages/75/3e/57ba7ea7ecb2f4751644ba91756e2be70e33ef5952c0c41a256a0e4c2437/ty-0.0.31-py3-none-win_amd64.whl", hash = "sha256:81134e25d2a2562ab372f24de8f9bd05034d27d30377a5d7540f259791c6234c", size = 11205258, upload-time = "2026-04-15T15:47:53.759Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/bca669095ccf0a400af941fdf741578d4c2d6719f1b7f10e6dbec10aa862/ty-0.0.31-py3-none-win_arm64.whl", hash = "sha256:e9cb15fad26545c6a608f40f227af3a5513cb376998ca6feddd47ca7d93ffafa", size = 10590392, upload-time = "2026-04-15T15:47:57.968Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2708,33 +2682,33 @@ wheels = [
 
 [[package]]
 name = "types-boto3"
-version = "1.42.88"
+version = "1.42.91"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore-stubs" },
     { name = "types-s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/1c/908dcdcf9859f0c848b0f9dd41783e2d6edffe6e4a25429836a7af426c47/types_boto3-1.42.88.tar.gz", hash = "sha256:5e449c9d030313d006d17d0fba9c8bac517d5250c9b40e258b5ad9604a30e2fd", size = 102881, upload-time = "2026-04-10T19:55:53.833Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/e3/c6172816bc83a27c58e2f2d9a0854470f22d06856655e3091bcf8be1bd2c/types_boto3-1.42.91.tar.gz", hash = "sha256:f85600f36d876184137df2289189a59792de35a7a5f2e50d3c2224cc150cbea8", size = 102982, upload-time = "2026-04-17T19:33:10.65Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/ec/605fc0a70224d2781c09b7057e522ca9a64431435cdb5fe1f14a7fe80c5c/types_boto3-1.42.88-py3-none-any.whl", hash = "sha256:1be5a0259f7352332256373686e9c8906a8d143d4678eb380b4402202fc9ef86", size = 70510, upload-time = "2026-04-10T19:55:48.852Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ca/77d844597a5e7476e5fed577a256b2b7f3b9968b52d81f388f3b0b6882a2/types_boto3-1.42.91-py3-none-any.whl", hash = "sha256:4abd8188ba75e53699addc4e547734b3e90b1582941b4e2bd97efd5441cf68f7", size = 70560, upload-time = "2026-04-17T19:33:07.618Z" },
 ]
 
 [[package]]
 name = "types-colorama"
-version = "0.4.15.20250801"
+version = "0.4.15.20260408"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/37/af713e7d73ca44738c68814cbacf7a655aa40ddd2e8513d431ba78ace7b3/types_colorama-0.4.15.20250801.tar.gz", hash = "sha256:02565d13d68963d12237d3f330f5ecd622a3179f7b5b14ee7f16146270c357f5", size = 10437, upload-time = "2025-08-01T03:48:22.605Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/c0/1c02ed9edf3462a392f4ea4bda80fa10c538c63d1d7be255dc7dcb545007/types_colorama-0.4.15.20260408.tar.gz", hash = "sha256:9a816657927489463edec1b7b47933b73fe737d37a3616bf596b7de843441032", size = 10623, upload-time = "2026-04-08T04:28:31.763Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/3a/44ccbbfef6235aeea84c74041dc6dfee6c17ff3ddba782a0250e41687ec7/types_colorama-0.4.15.20250801-py3-none-any.whl", hash = "sha256:b6e89bd3b250fdad13a8b6a465c933f4a5afe485ea2e2f104d739be50b13eea9", size = 10743, upload-time = "2025-08-01T03:48:21.774Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/65/d03948be8ae9362ad26f36443eab051fe5524295fe008126cd65792f9833/types_colorama-0.4.15.20260408-py3-none-any.whl", hash = "sha256:7327a51c760d94f7df2e8c72c275a4468c03c3abb606d23995cb37e3d24d9132", size = 10763, upload-time = "2026-04-08T04:28:30.688Z" },
 ]
 
 [[package]]
 name = "types-decorator"
-version = "5.2.0.20251101"
+version = "5.2.0.20260408"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a6/e4/929a77f6580928a5b4914a62834a0570d2449428ecdbb0a2e916150ed978/types_decorator-5.2.0.20251101.tar.gz", hash = "sha256:120e2bf4792ec8a47653db1cb380c7aacb6862a797c1490a910aacc21548286c", size = 9059, upload-time = "2025-11-01T03:04:02.355Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/8f/b409aa8260c73ee91361ef66df80900da8d8f5151c807aa278b1bb558f1e/types_decorator-5.2.0.20260408.tar.gz", hash = "sha256:d1d4c10067545657b8046677d6e2b823147665bfd5f244395e681bdd1039c80e", size = 9183, upload-time = "2026-04-08T04:30:57.514Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/cc/aa53df63915e10d429b7aa0491ba520abe4b80aef0304d1b02425cd5bd08/types_decorator-5.2.0.20251101-py3-none-any.whl", hash = "sha256:8176470ec0a2190e9d688577d4987b24039ae4a23913211707eda96bf2755b0c", size = 8074, upload-time = "2025-11-01T03:04:01.353Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c0/9672e9c63085a2e20c045a535ce912942772d497b0fd0417dabe086ffe31/types_decorator-5.2.0.20260408-py3-none-any.whl", hash = "sha256:4b01272677fd627604fbb8fee048cff9c4df00583d1c071b4505304b5881a7ac", size = 8076, upload-time = "2026-04-08T04:30:56.531Z" },
 ]
 
 [[package]]
@@ -2760,26 +2734,26 @@ wheels = [
 
 [[package]]
 name = "types-jsonschema"
-version = "4.26.0.20260402"
+version = "4.26.0.20260408"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "referencing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/d3/026e247db60c9cb7db2dee659793ca46fe33bcac53f00f318a688fb176a3/types_jsonschema-4.26.0.20260402.tar.gz", hash = "sha256:03d0f697a9930970033e29e91da45accf287ee44d5eed6f7a238b99e608b23f4", size = 16520, upload-time = "2026-04-02T04:20:19.135Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4c/2ef5483ef81e7b6e1b901eb2994fd280cb19860134a20ff99e72748f3ccb/types_jsonschema-4.26.0.20260408.tar.gz", hash = "sha256:82b75a976ed1507c473b8dee2d4841bd65926758c6d672bb93d08bf5e16f1b3f", size = 16553, upload-time = "2026-04-08T04:36:00.543Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/5e/02f58a194ffe7ac02657ca590c46348220c04a76a62e2ceb45a5ac0cd666/types_jsonschema-4.26.0.20260402-py3-none-any.whl", hash = "sha256:0e8ebd94b257fc978b41b89c7b9bc76232e104e5125ec19009c4f60844c96e0a", size = 16082, upload-time = "2026-04-02T04:20:17.922Z" },
+    { url = "https://files.pythonhosted.org/packages/12/3c/724ad6ecaea06e8c6c8a8c9949a0979e6a2149b8aec4fe160135c64dd5ac/types_jsonschema-4.26.0.20260408-py3-none-any.whl", hash = "sha256:1ab0058c2612b0b81fc4e3c88ec3f9ad9b0af3fd31a176030d78b6d6cefb6e7b", size = 16081, upload-time = "2026-04-08T04:35:59.678Z" },
 ]
 
 [[package]]
 name = "types-pygments"
-version = "2.19.0.20260402"
+version = "2.20.0.20260408"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "types-docutils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/a8/5834c55d900ce31b31367eedb82e664347dfa551a957b74a0ce0cd9f4f9a/types_pygments-2.19.0.20260402.tar.gz", hash = "sha256:bd26e1f662c9a3b8ea56668ddc099b809ffd54931bee97b15853bc4a8e5d4250", size = 18808, upload-time = "2026-04-02T04:21:13.058Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/89/4b443128fa540c54a8f7ecdeec225aab4818534167c4a2d133099dc00fa6/types_pygments-2.20.0.20260408.tar.gz", hash = "sha256:e8a56a3ab1aee7f4ed8f1876d2f62c96e0f41ede52405a7d30c888f3989d8f00", size = 21115, upload-time = "2026-04-08T04:34:24.29Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/f2/b23659df4219fc4f39a45ede527cc209d961c7ff957678536a7a9d9ac9c5/types_pygments-2.19.0.20260402-py3-none-any.whl", hash = "sha256:5b0d863cec1c43ba38c946fb6e89d389c1cf287806f72360336fba4482f8daeb", size = 25672, upload-time = "2026-04-02T04:21:11.916Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d8/30924b38eef70caef6b05af5440c84d7673cea2a042e206f404c8100a88d/types_pygments-2.20.0.20260408-py3-none-any.whl", hash = "sha256:6d347d5967b5f0654b659a8b8461a870b207b7e60cd4d646bbc047f6a8db8e1e", size = 29055, upload-time = "2026-04-08T04:34:23.412Z" },
 ]
 
 [[package]]
@@ -2811,11 +2785,11 @@ wheels = [
 
 [[package]]
 name = "types-six"
-version = "1.17.0.20251009"
+version = "1.17.0.20260408"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/f7/448215bc7695cfa0c8a7e0dcfa54fe31b1d52fb87004fed32e659dd85c80/types_six-1.17.0.20251009.tar.gz", hash = "sha256:efe03064ecd0ffb0f7afe133990a2398d8493d8d1c1cc10ff3dfe476d57ba44f", size = 15552, upload-time = "2025-10-09T02:54:26.02Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/95/14bb40b2fa8f19234d60b370bfa1ff64b42509b6d2dee070132949ce4f80/types_six-1.17.0.20260408.tar.gz", hash = "sha256:b28579aedb204d07abac52e49c87e2b4c03cb6171bd764bd9b7775ba58fffaba", size = 15766, upload-time = "2026-04-08T04:26:23.54Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/2f/94baa623421940e3eb5d2fc63570ebb046f2bb4d9573b8787edab3ed2526/types_six-1.17.0.20251009-py3-none-any.whl", hash = "sha256:2494f4c2a58ada0edfe01ea84b58468732e43394c572d9cf5b1dd06d86c487a3", size = 19935, upload-time = "2025-10-09T02:54:25.096Z" },
+    { url = "https://files.pythonhosted.org/packages/83/04/3e9c382043579b5170c3bc38d13154d48e8ef2c89c4473748a33e3c9bccd/types_six-1.17.0.20260408-py3-none-any.whl", hash = "sha256:02208fa1099944ed0c8f8de42f065ffd63c55cd7b59f49be49802626b8d58318", size = 19937, upload-time = "2026-04-08T04:26:22.259Z" },
 ]
 
 [[package]]
@@ -2998,48 +2972,50 @@ wheels = [
 
 [[package]]
 name = "yarl"
-version = "1.20.1"
+version = "1.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "multidict" },
     { name = "propcache" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/fb/efaa23fa4e45537b827620f04cf8f3cd658b76642205162e072703a5b963/yarl-1.20.1.tar.gz", hash = "sha256:d017a4997ee50c91fd5466cef416231bb82177b93b029906cefc542ce14c35ac", size = 186428, upload-time = "2025-06-10T00:46:09.923Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/6e/beb1beec874a72f23815c1434518bfc4ed2175065173fb138c3705f658d4/yarl-1.23.0.tar.gz", hash = "sha256:53b1ea6ca88ebd4420379c330aea57e258408dd0df9af0992e5de2078dc9f5d5", size = 194676, upload-time = "2026-03-01T22:07:53.373Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/e1/2411b6d7f769a07687acee88a062af5833cf1966b7266f3d8dfb3d3dc7d3/yarl-1.20.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:0b5ff0fbb7c9f1b1b5ab53330acbfc5247893069e7716840c8e7d5bb7355038a", size = 131811, upload-time = "2025-06-10T00:44:18.933Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/27/584394e1cb76fb771371770eccad35de400e7b434ce3142c2dd27392c968/yarl-1.20.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:14f326acd845c2b2e2eb38fb1346c94f7f3b01a4f5c788f8144f9b630bfff9a3", size = 90078, upload-time = "2025-06-10T00:44:20.635Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/9a/3246ae92d4049099f52d9b0fe3486e3b500e29b7ea872d0f152966fc209d/yarl-1.20.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f60e4ad5db23f0b96e49c018596707c3ae89f5d0bd97f0ad3684bcbad899f1e7", size = 88748, upload-time = "2025-06-10T00:44:22.34Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/25/35afe384e31115a1a801fbcf84012d7a066d89035befae7c5d4284df1e03/yarl-1.20.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:49bdd1b8e00ce57e68ba51916e4bb04461746e794e7c4d4bbc42ba2f18297691", size = 349595, upload-time = "2025-06-10T00:44:24.314Z" },
-    { url = "https://files.pythonhosted.org/packages/28/2d/8aca6cb2cabc8f12efcb82749b9cefecbccfc7b0384e56cd71058ccee433/yarl-1.20.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:66252d780b45189975abfed839616e8fd2dbacbdc262105ad7742c6ae58f3e31", size = 342616, upload-time = "2025-06-10T00:44:26.167Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/e9/1312633d16b31acf0098d30440ca855e3492d66623dafb8e25b03d00c3da/yarl-1.20.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:59174e7332f5d153d8f7452a102b103e2e74035ad085f404df2e40e663a22b28", size = 361324, upload-time = "2025-06-10T00:44:27.915Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/a0/688cc99463f12f7669eec7c8acc71ef56a1521b99eab7cd3abb75af887b0/yarl-1.20.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e3968ec7d92a0c0f9ac34d5ecfd03869ec0cab0697c91a45db3fbbd95fe1b653", size = 359676, upload-time = "2025-06-10T00:44:30.041Z" },
-    { url = "https://files.pythonhosted.org/packages/af/44/46407d7f7a56e9a85a4c207724c9f2c545c060380718eea9088f222ba697/yarl-1.20.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1a4fbb50e14396ba3d375f68bfe02215d8e7bc3ec49da8341fe3157f59d2ff5", size = 352614, upload-time = "2025-06-10T00:44:32.171Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/91/31163295e82b8d5485d31d9cf7754d973d41915cadce070491778d9c9825/yarl-1.20.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:11a62c839c3a8eac2410e951301309426f368388ff2f33799052787035793b02", size = 336766, upload-time = "2025-06-10T00:44:34.494Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/8e/c41a5bc482121f51c083c4c2bcd16b9e01e1cf8729e380273a952513a21f/yarl-1.20.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:041eaa14f73ff5a8986b4388ac6bb43a77f2ea09bf1913df7a35d4646db69e53", size = 364615, upload-time = "2025-06-10T00:44:36.856Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/5b/61a3b054238d33d70ea06ebba7e58597891b71c699e247df35cc984ab393/yarl-1.20.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:377fae2fef158e8fd9d60b4c8751387b8d1fb121d3d0b8e9b0be07d1b41e83dc", size = 360982, upload-time = "2025-06-10T00:44:39.141Z" },
-    { url = "https://files.pythonhosted.org/packages/df/a3/6a72fb83f8d478cb201d14927bc8040af901811a88e0ff2da7842dd0ed19/yarl-1.20.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1c92f4390e407513f619d49319023664643d3339bd5e5a56a3bebe01bc67ec04", size = 369792, upload-time = "2025-06-10T00:44:40.934Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/af/4cc3c36dfc7c077f8dedb561eb21f69e1e9f2456b91b593882b0b18c19dc/yarl-1.20.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d25ddcf954df1754ab0f86bb696af765c5bfaba39b74095f27eececa049ef9a4", size = 382049, upload-time = "2025-06-10T00:44:42.854Z" },
-    { url = "https://files.pythonhosted.org/packages/19/3a/e54e2c4752160115183a66dc9ee75a153f81f3ab2ba4bf79c3c53b33de34/yarl-1.20.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:909313577e9619dcff8c31a0ea2aa0a2a828341d92673015456b3ae492e7317b", size = 384774, upload-time = "2025-06-10T00:44:45.275Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/20/200ae86dabfca89060ec6447649f219b4cbd94531e425e50d57e5f5ac330/yarl-1.20.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:793fd0580cb9664548c6b83c63b43c477212c0260891ddf86809e1c06c8b08f1", size = 374252, upload-time = "2025-06-10T00:44:47.31Z" },
-    { url = "https://files.pythonhosted.org/packages/83/75/11ee332f2f516b3d094e89448da73d557687f7d137d5a0f48c40ff211487/yarl-1.20.1-cp313-cp313-win32.whl", hash = "sha256:468f6e40285de5a5b3c44981ca3a319a4b208ccc07d526b20b12aeedcfa654b7", size = 81198, upload-time = "2025-06-10T00:44:49.164Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/ba/39b1ecbf51620b40ab402b0fc817f0ff750f6d92712b44689c2c215be89d/yarl-1.20.1-cp313-cp313-win_amd64.whl", hash = "sha256:495b4ef2fea40596bfc0affe3837411d6aa3371abcf31aac0ccc4bdd64d4ef5c", size = 86346, upload-time = "2025-06-10T00:44:51.182Z" },
-    { url = "https://files.pythonhosted.org/packages/43/c7/669c52519dca4c95153c8ad96dd123c79f354a376346b198f438e56ffeb4/yarl-1.20.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f60233b98423aab21d249a30eb27c389c14929f47be8430efa7dbd91493a729d", size = 138826, upload-time = "2025-06-10T00:44:52.883Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/42/fc0053719b44f6ad04a75d7f05e0e9674d45ef62f2d9ad2c1163e5c05827/yarl-1.20.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6f3eff4cc3f03d650d8755c6eefc844edde99d641d0dcf4da3ab27141a5f8ddf", size = 93217, upload-time = "2025-06-10T00:44:54.658Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/7f/fa59c4c27e2a076bba0d959386e26eba77eb52ea4a0aac48e3515c186b4c/yarl-1.20.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:69ff8439d8ba832d6bed88af2c2b3445977eba9a4588b787b32945871c2444e3", size = 92700, upload-time = "2025-06-10T00:44:56.784Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/d4/062b2f48e7c93481e88eff97a6312dca15ea200e959f23e96d8ab898c5b8/yarl-1.20.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3cf34efa60eb81dd2645a2e13e00bb98b76c35ab5061a3989c7a70f78c85006d", size = 347644, upload-time = "2025-06-10T00:44:59.071Z" },
-    { url = "https://files.pythonhosted.org/packages/89/47/78b7f40d13c8f62b499cc702fdf69e090455518ae544c00a3bf4afc9fc77/yarl-1.20.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8e0fe9364ad0fddab2688ce72cb7a8e61ea42eff3c7caeeb83874a5d479c896c", size = 323452, upload-time = "2025-06-10T00:45:01.605Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/2b/490d3b2dc66f52987d4ee0d3090a147ea67732ce6b4d61e362c1846d0d32/yarl-1.20.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f64fbf81878ba914562c672024089e3401974a39767747691c65080a67b18c1", size = 346378, upload-time = "2025-06-10T00:45:03.946Z" },
-    { url = "https://files.pythonhosted.org/packages/66/ad/775da9c8a94ce925d1537f939a4f17d782efef1f973039d821cbe4bcc211/yarl-1.20.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f6342d643bf9a1de97e512e45e4b9560a043347e779a173250824f8b254bd5ce", size = 353261, upload-time = "2025-06-10T00:45:05.992Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/23/0ed0922b47a4f5c6eb9065d5ff1e459747226ddce5c6a4c111e728c9f701/yarl-1.20.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56dac5f452ed25eef0f6e3c6a066c6ab68971d96a9fb441791cad0efba6140d3", size = 335987, upload-time = "2025-06-10T00:45:08.227Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/49/bc728a7fe7d0e9336e2b78f0958a2d6b288ba89f25a1762407a222bf53c3/yarl-1.20.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7d7f497126d65e2cad8dc5f97d34c27b19199b6414a40cb36b52f41b79014be", size = 329361, upload-time = "2025-06-10T00:45:10.11Z" },
-    { url = "https://files.pythonhosted.org/packages/93/8f/b811b9d1f617c83c907e7082a76e2b92b655400e61730cd61a1f67178393/yarl-1.20.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:67e708dfb8e78d8a19169818eeb5c7a80717562de9051bf2413aca8e3696bf16", size = 346460, upload-time = "2025-06-10T00:45:12.055Z" },
-    { url = "https://files.pythonhosted.org/packages/70/fd/af94f04f275f95da2c3b8b5e1d49e3e79f1ed8b6ceb0f1664cbd902773ff/yarl-1.20.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:595c07bc79af2494365cc96ddeb772f76272364ef7c80fb892ef9d0649586513", size = 334486, upload-time = "2025-06-10T00:45:13.995Z" },
-    { url = "https://files.pythonhosted.org/packages/84/65/04c62e82704e7dd0a9b3f61dbaa8447f8507655fd16c51da0637b39b2910/yarl-1.20.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7bdd2f80f4a7df852ab9ab49484a4dee8030023aa536df41f2d922fd57bf023f", size = 342219, upload-time = "2025-06-10T00:45:16.479Z" },
-    { url = "https://files.pythonhosted.org/packages/91/95/459ca62eb958381b342d94ab9a4b6aec1ddec1f7057c487e926f03c06d30/yarl-1.20.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:c03bfebc4ae8d862f853a9757199677ab74ec25424d0ebd68a0027e9c639a390", size = 350693, upload-time = "2025-06-10T00:45:18.399Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/00/d393e82dd955ad20617abc546a8f1aee40534d599ff555ea053d0ec9bf03/yarl-1.20.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:344d1103e9c1523f32a5ed704d576172d2cabed3122ea90b1d4e11fe17c66458", size = 355803, upload-time = "2025-06-10T00:45:20.677Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/ed/c5fb04869b99b717985e244fd93029c7a8e8febdfcffa06093e32d7d44e7/yarl-1.20.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:88cab98aa4e13e1ade8c141daeedd300a4603b7132819c484841bb7af3edce9e", size = 341709, upload-time = "2025-06-10T00:45:23.221Z" },
-    { url = "https://files.pythonhosted.org/packages/24/fd/725b8e73ac2a50e78a4534ac43c6addf5c1c2d65380dd48a9169cc6739a9/yarl-1.20.1-cp313-cp313t-win32.whl", hash = "sha256:b121ff6a7cbd4abc28985b6028235491941b9fe8fe226e6fdc539c977ea1739d", size = 86591, upload-time = "2025-06-10T00:45:25.793Z" },
-    { url = "https://files.pythonhosted.org/packages/94/c3/b2e9f38bc3e11191981d57ea08cab2166e74ea770024a646617c9cddd9f6/yarl-1.20.1-cp313-cp313t-win_amd64.whl", hash = "sha256:541d050a355bbbc27e55d906bc91cb6fe42f96c01413dd0f4ed5a5240513874f", size = 93003, upload-time = "2025-06-10T00:45:27.752Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/2d/2345fce04cfd4bee161bf1e7d9cdc702e3e16109021035dbb24db654a622/yarl-1.20.1-py3-none-any.whl", hash = "sha256:83b8eb083fe4683c6115795d9fc1cfaf2cbbefb19b3a1cb68f6527460f483a77", size = 46542, upload-time = "2025-06-10T00:46:07.521Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4b/a0a6e5d0ee8a2f3a373ddef8a4097d74ac901ac363eea1440464ccbe0898/yarl-1.23.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:16c6994ac35c3e74fb0ae93323bf8b9c2a9088d55946109489667c510a7d010e", size = 123796, upload-time = "2026-03-01T22:05:41.412Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b6/8925d68af039b835ae876db5838e82e76ec87b9782ecc97e192b809c4831/yarl-1.23.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4a42e651629dafb64fd5b0286a3580613702b5809ad3f24934ea87595804f2c5", size = 86547, upload-time = "2026-03-01T22:05:42.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/50/06d511cc4b8e0360d3c94af051a768e84b755c5eb031b12adaaab6dec6e5/yarl-1.23.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c6b9461a2a8b47c65eef63bb1c76a4f1c119618ffa99ea79bc5bb1e46c5821b", size = 85854, upload-time = "2026-03-01T22:05:44.85Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f4/4e30b250927ffdab4db70da08b9b8d2194d7c7b400167b8fbeca1e4701ca/yarl-1.23.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2569b67d616eab450d262ca7cb9f9e19d2f718c70a8b88712859359d0ab17035", size = 98351, upload-time = "2026-03-01T22:05:46.836Z" },
+    { url = "https://files.pythonhosted.org/packages/86/fc/4118c5671ea948208bdb1492d8b76bdf1453d3e73df051f939f563e7dcc5/yarl-1.23.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e9d9a4d06d3481eab79803beb4d9bd6f6a8e781ec078ac70d7ef2dcc29d1bea5", size = 92711, upload-time = "2026-03-01T22:05:48.316Z" },
+    { url = "https://files.pythonhosted.org/packages/56/11/1ed91d42bd9e73c13dc9e7eb0dd92298d75e7ac4dd7f046ad0c472e231cd/yarl-1.23.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f514f6474e04179d3d33175ed3f3e31434d3130d42ec153540d5b157deefd735", size = 106014, upload-time = "2026-03-01T22:05:50.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/c9/74e44e056a23fbc33aca71779ef450ca648a5bc472bdad7a82339918f818/yarl-1.23.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fda207c815b253e34f7e1909840fd14299567b1c0eb4908f8c2ce01a41265401", size = 105557, upload-time = "2026-03-01T22:05:51.416Z" },
+    { url = "https://files.pythonhosted.org/packages/66/fe/b1e10b08d287f518994f1e2ff9b6d26f0adeecd8dd7d533b01bab29a3eda/yarl-1.23.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34b6cf500e61c90f305094911f9acc9c86da1a05a7a3f5be9f68817043f486e4", size = 101559, upload-time = "2026-03-01T22:05:52.872Z" },
+    { url = "https://files.pythonhosted.org/packages/72/59/c5b8d94b14e3d3c2a9c20cb100119fd534ab5a14b93673ab4cc4a4141ea5/yarl-1.23.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d7504f2b476d21653e4d143f44a175f7f751cd41233525312696c76aa3dbb23f", size = 100502, upload-time = "2026-03-01T22:05:54.954Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4f/96976cb54cbfc5c9fd73ed4c51804f92f209481d1fb190981c0f8a07a1d7/yarl-1.23.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:578110dd426f0d209d1509244e6d4a3f1a3e9077655d98c5f22583d63252a08a", size = 98027, upload-time = "2026-03-01T22:05:56.409Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6e/904c4f476471afdbad6b7e5b70362fb5810e35cd7466529a97322b6f5556/yarl-1.23.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:609d3614d78d74ebe35f54953c5bbd2ac647a7ddb9c30a5d877580f5e86b22f2", size = 95369, upload-time = "2026-03-01T22:05:58.141Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/40/acfcdb3b5f9d68ef499e39e04d25e141fe90661f9d54114556cf83be8353/yarl-1.23.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4966242ec68afc74c122f8459abd597afd7d8a60dc93d695c1334c5fd25f762f", size = 105565, upload-time = "2026-03-01T22:06:00.286Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c6/31e28f3a6ba2869c43d124f37ea5260cac9c9281df803c354b31f4dd1f3c/yarl-1.23.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e0fd068364a6759bc794459f0a735ab151d11304346332489c7972bacbe9e72b", size = 99813, upload-time = "2026-03-01T22:06:01.712Z" },
+    { url = "https://files.pythonhosted.org/packages/08/1f/6f65f59e72d54aa467119b63fc0b0b1762eff0232db1f4720cd89e2f4a17/yarl-1.23.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:39004f0ad156da43e86aa71f44e033de68a44e5a31fc53507b36dd253970054a", size = 105632, upload-time = "2026-03-01T22:06:03.188Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c4/18b178a69935f9e7a338127d5b77d868fdc0f0e49becd286d51b3a18c61d/yarl-1.23.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e5723c01a56c5028c807c701aa66722916d2747ad737a046853f6c46f4875543", size = 101895, upload-time = "2026-03-01T22:06:04.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/54/f5b870b5505663911dba950a8e4776a0dbd51c9c54c0ae88e823e4b874a0/yarl-1.23.0-cp313-cp313-win32.whl", hash = "sha256:1b6b572edd95b4fa8df75de10b04bc81acc87c1c7d16bcdd2035b09d30acc957", size = 82356, upload-time = "2026-03-01T22:06:06.04Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/84/266e8da36879c6edcd37b02b547e2d9ecdfea776be49598e75696e3316e1/yarl-1.23.0-cp313-cp313-win_amd64.whl", hash = "sha256:baaf55442359053c7d62f6f8413a62adba3205119bcb6f49594894d8be47e5e3", size = 87515, upload-time = "2026-03-01T22:06:08.107Z" },
+    { url = "https://files.pythonhosted.org/packages/00/fd/7e1c66efad35e1649114fa13f17485f62881ad58edeeb7f49f8c5e748bf9/yarl-1.23.0-cp313-cp313-win_arm64.whl", hash = "sha256:fb4948814a2a98e3912505f09c9e7493b1506226afb1f881825368d6fb776ee3", size = 81785, upload-time = "2026-03-01T22:06:10.181Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/fc/119dd07004f17ea43bb91e3ece6587759edd7519d6b086d16bfbd3319982/yarl-1.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:aecfed0b41aa72b7881712c65cf764e39ce2ec352324f5e0837c7048d9e6daaa", size = 130719, upload-time = "2026-03-01T22:06:11.708Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/0d/9f2348502fbb3af409e8f47730282cd6bc80dec6630c1e06374d882d6eb2/yarl-1.23.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a41bcf68efd19073376eb8cf948b8d9be0af26256403e512bb18f3966f1f9120", size = 89690, upload-time = "2026-03-01T22:06:13.429Z" },
+    { url = "https://files.pythonhosted.org/packages/50/93/e88f3c80971b42cfc83f50a51b9d165a1dbf154b97005f2994a79f212a07/yarl-1.23.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cde9a2ecd91668bcb7f077c4966d8ceddb60af01b52e6e3e2680e4cf00ad1a59", size = 89851, upload-time = "2026-03-01T22:06:15.53Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/07/61c9dd8ba8f86473263b4036f70fb594c09e99c0d9737a799dfd8bc85651/yarl-1.23.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5023346c4ee7992febc0068e7593de5fa2bf611848c08404b35ebbb76b1b0512", size = 95874, upload-time = "2026-03-01T22:06:17.553Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e9/f9ff8ceefba599eac6abddcfb0b3bee9b9e636e96dbf54342a8577252379/yarl-1.23.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d1009abedb49ae95b136a8904a3f71b342f849ffeced2d3747bf29caeda218c4", size = 88710, upload-time = "2026-03-01T22:06:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/78/0231bfcc5d4c8eec220bc2f9ef82cb4566192ea867a7c5b4148f44f6cbcd/yarl-1.23.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a8d00f29b42f534cc8aa3931cfe773b13b23e561e10d2b26f27a8d309b0e82a1", size = 101033, upload-time = "2026-03-01T22:06:21.203Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/9b/30ea5239a61786f18fd25797151a17fbb3be176977187a48d541b5447dd4/yarl-1.23.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:95451e6ce06c3e104556d73b559f5da6c34a069b6b62946d3ad66afcd51642ea", size = 100817, upload-time = "2026-03-01T22:06:22.738Z" },
+    { url = "https://files.pythonhosted.org/packages/62/e2/a4980481071791bc83bce2b7a1a1f7adcabfa366007518b4b845e92eeee3/yarl-1.23.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531ef597132086b6cf96faa7c6c1dcd0361dd5f1694e5cc30375907b9b7d3ea9", size = 97482, upload-time = "2026-03-01T22:06:24.21Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1e/304a00cf5f6100414c4b5a01fc7ff9ee724b62158a08df2f8170dfc72a2d/yarl-1.23.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:88f9fb0116fbfcefcab70f85cf4b74a2b6ce5d199c41345296f49d974ddb4123", size = 95949, upload-time = "2026-03-01T22:06:25.697Z" },
+    { url = "https://files.pythonhosted.org/packages/68/03/093f4055ed4cae649ac53bca3d180bd37102e9e11d048588e9ab0c0108d0/yarl-1.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e7b0460976dc75cb87ad9cc1f9899a4b97751e7d4e77ab840fc9b6d377b8fd24", size = 95839, upload-time = "2026-03-01T22:06:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/28/4c75ebb108f322aa8f917ae10a8ffa4f07cae10a8a627b64e578617df6a0/yarl-1.23.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:115136c4a426f9da976187d238e84139ff6b51a20839aa6e3720cd1026d768de", size = 90696, upload-time = "2026-03-01T22:06:29.048Z" },
+    { url = "https://files.pythonhosted.org/packages/23/9c/42c2e2dd91c1a570402f51bdf066bfdb1241c2240ba001967bad778e77b7/yarl-1.23.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:ead11956716a940c1abc816b7df3fa2b84d06eaed8832ca32f5c5e058c65506b", size = 100865, upload-time = "2026-03-01T22:06:30.525Z" },
+    { url = "https://files.pythonhosted.org/packages/74/05/1bcd60a8a0a914d462c305137246b6f9d167628d73568505fce3f1cb2e65/yarl-1.23.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:fe8f8f5e70e6dbdfca9882cd9deaac058729bcf323cf7a58660901e55c9c94f6", size = 96234, upload-time = "2026-03-01T22:06:32.692Z" },
+    { url = "https://files.pythonhosted.org/packages/90/b2/f52381aac396d6778ce516b7bc149c79e65bfc068b5de2857ab69eeea3b7/yarl-1.23.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:a0e317df055958a0c1e79e5d2aa5a5eaa4a6d05a20d4b0c9c3f48918139c9fc6", size = 100295, upload-time = "2026-03-01T22:06:34.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/638bae5bbf1113a659b2435d8895474598afe38b4a837103764f603aba56/yarl-1.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6f0fd84de0c957b2d280143522c4f91a73aada1923caee763e24a2b3fda9f8a5", size = 97784, upload-time = "2026-03-01T22:06:35.864Z" },
+    { url = "https://files.pythonhosted.org/packages/80/25/a3892b46182c586c202629fc2159aa13975d3741d52ebd7347fd501d48d5/yarl-1.23.0-cp313-cp313t-win32.whl", hash = "sha256:93a784271881035ab4406a172edb0faecb6e7d00f4b53dc2f55919d6c9688595", size = 88313, upload-time = "2026-03-01T22:06:37.39Z" },
+    { url = "https://files.pythonhosted.org/packages/43/68/8c5b36aa5178900b37387937bc2c2fe0e9505537f713495472dcf6f6fccc/yarl-1.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dd00607bffbf30250fe108065f07453ec124dbf223420f57f5e749b04295e090", size = 94932, upload-time = "2026-03-01T22:06:39.579Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/cc/d79ba8292f51f81f4dc533a8ccfb9fc6992cabf0998ed3245de7589dc07c/yarl-1.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:ac09d42f48f80c9ee1635b2fcaa819496a44502737660d3c0f2ade7526d29144", size = 84786, upload-time = "2026-03-01T22:06:41.988Z" },
+    { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
 ]


### PR DESCRIPTION
Adds the concept of `SourceAdapters` to the BNA store to simplify the
way we handle downloading, preparing and validating files from various
sources.

The `cache-warmer` utility was updated to actually be useful and
pre-populate the user cache with the datasets used by the analyzer.

The `bna-batch` utility was updated to reflect the changes and the
custom logic to cache OSM files was removed.

Drive-by:
- Replaces `mypy` with `ty`.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
