### PR TITLE
Add S3 support to cache-warmer

### DIFF
--- a/brokenspoke_analyzer/core/datastore.py
+++ b/brokenspoke_analyzer/core/datastore.py
@@ -6,7 +6,9 @@ import enum
 import pathlib
 from typing import TYPE_CHECKING
 
+import aiohttp
 from loguru import logger
+from obstore import exceptions as obstore_exceptions
 from obstore.store import (
     from_url,
 )
@@ -18,7 +20,6 @@ from brokenspoke_analyzer.core import (
 )
 
 if TYPE_CHECKING:
-    import aiohttp
     from obstore.store import ObjectStore
 
 
@@ -136,6 +137,41 @@ class BNADataStore:
         res = await self.cache.get_async(path)
         await self.store.put_async(destination_path, res)
 
+    async def _cleanup_partial_cache(self, path: str) -> None:
+        """Delete a partially written cache artifact if the cache store supports it."""
+        delete_async = getattr(self.cache, "delete_async", None)
+        if callable(delete_async):
+            try:
+                await delete_async(path)
+            except FileNotFoundError:
+                return
+            except (obstore_exceptions.BaseError, OSError) as exc:
+                logger.warning(
+                    "failed to delete partial cache object %s: %s",
+                    path,
+                    exc,
+                )
+            return
+
+        delete_sync = getattr(self.cache, "delete", None)
+        if callable(delete_sync):
+            try:
+                delete_sync(path)
+            except FileNotFoundError:
+                return
+            except (obstore_exceptions.BaseError, OSError) as exc:
+                logger.warning(
+                    "failed to delete partial cache object %s: %s",
+                    path,
+                    exc,
+                )
+            return
+
+        logger.warning(
+            "cache store does not support delete; partial artifact may remain: %s",
+            path,
+        )
+
     async def fetch_to_cache(
         self,
         session: aiohttp.ClientSession,
@@ -151,7 +187,17 @@ class BNADataStore:
 
         # If not, download it from the url and store it into the cache data store.
         async with session.get(url) as resp:
-            await self.cache.put_async(path, resp.content.iter_chunked(CHUNK_SIZE))
+            resp.raise_for_status()
+            try:
+                await self.cache.put_async(path, resp.content.iter_chunked(CHUNK_SIZE))
+            except (
+                aiohttp.ClientError,
+                obstore_exceptions.BaseError,
+                OSError,
+                RuntimeError,
+            ):
+                await self._cleanup_partial_cache(path)
+                raise
 
     async def fetch(
         self,

--- a/specs/0001-cache-warmer-s3/design.md
+++ b/specs/0001-cache-warmer-s3/design.md
@@ -1,0 +1,162 @@
+# Design: Cache-Warmer S3
+
+This document describes the design to add an `s3` subcommand to the
+`cache-warmer` utility so it can populate an AWS S3 bucket directly from
+upstream sources (no local writes). It focuses on the CLI/registry pattern,
+storage backend injection, streaming data flow, failure cleanup, and concrete
+code changes.
+
+## Goals
+
+- Reuse all download logic in `brokenspoke_analyzer/core/datastore.py`.
+- Stream downloads directly into S3 using `obstore` so no local files are
+  created.
+- Keep operations asynchronous and sequential per artifact.
+- Fail fast on any error and remove partial objects.
+
+## High-level Architecture
+
+- CLI: `utils/cache-warmer.py` becomes a small `typer` app with two subcommands:
+  - `local` — existing behavior (populate local user cache)
+  - `s3` — new behavior (stream artifacts to S3)
+
+- Datastore: `BNADataStore` remains the source of truth for download logic. For
+  `s3` runs we will inject an S3-backed `obstore` store into the
+  `BNADataStore.cache` attribute so existing `fetch_to_cache` /
+  `fetch_from_source` methods write directly to S3 keys.
+
+- Storage primitives:
+  - Use `brokenspoke_analyzer.core.exporter.create_s3_store(bucket_name)`
+    (already present) to create an `obstore` `ObjectStore` for the bucket.
+  - For cleanup and bucket-specific operations (if needed) use
+    `brokenspoke_analyzer.core.exporter.get_s3_bucket(bucket_name)` which
+    returns a `boto3` Bucket instance.
+
+## Data flow
+
+1. Invoke `cache-warmer s3 --bucket my-bucket`.
+2. CLI creates an `ObjectStore` for `s3://my-bucket` via `create_s3_store`.
+3. Instantiate `BNADataStore` (any CacheType is acceptable) and replace
+   `bna_store.cache` with the S3 `ObjectStore`.
+4. For each SourceAdapter the existing code calls
+   `fetch_from_source(session, source)` which internally computes
+   `path = str(source.subpath / url.name)` (for example
+   `census/tl_2020_06_tabblock20.zip`).
+5. `fetch_to_cache` calls
+   `self.cache.put_async(path, resp.content.iter_chunked(CHUNK_SIZE))` — because
+   `self.cache` is an S3 `ObjectStore`, this streams the HTTP response directly
+   into the S3 object with key `census/...`, satisfying the required top-level
+   prefixes.
+6. On success, proceed to next artifact; on error, perform cleanup and abort.
+
+Notes:
+
+- The `SourceAdapter.subpath` values (e.g., `census`, `lodes`, `osm`,
+  `state_speed_limits`, `city_speed_limits`) already align with the required
+  top-level prefixes; no extra mapping is necessary.
+
+## Failure handling and cleanup
+
+- Requirement: no partial objects remain on failure.
+- Strategy:
+  1. Wrap each call to `fetch_to_cache` in try/except.
+  2. If an exception occurs during download or streaming, attempt to delete the
+     partially created key.
+     - Use `boto3` via `get_s3_bucket(bucket_name)` to delete the object
+       (`bucket.Object(key).delete()`), because `obstore` implementations may
+       expose different internals; exporter already exposes `get_s3_bucket` for
+       such operations.
+  3. Log the underlying error with `loguru`/`Rich` and exit non-zero.
+
+Implementation details:
+
+- Where possible rely on `obstore`'s (and underlying client) default retries; do
+  not implement custom retry logic.
+
+## Concurrency and performance
+
+- Downloads will remain asynchronous but executed sequentially per artifact (the
+  existing code structure already loops sequentially). This satisfies the
+  requirement and keeps the implementation simple and predictable.
+
+## Concrete changes (files & snippets)
+
+### 1) `utils/cache-warmer.py`
+
+- Convert the script into a `typer` app with two subcommands:
+  - `local`: reuses the existing `main()` logic unchanged (writes to local
+    cache)
+  - `s3`: new subcommand that accepts `--bucket` and `--mirror` and streams
+    artifacts to S3
+
+- Key `s3` implementation sketch (pseudo):
+
+```py
+import typer
+from brokenspoke_analyzer.core import exporter
+
+app = typer.Typer()
+
+@app.command()
+def s3(bucket: str, mirror: str | None = None) -> None:
+    # Create S3 obstore store and boto3 bucket
+    s3_store = exporter.create_s3_store(bucket)
+    s3_bucket = exporter.get_s3_bucket(bucket)
+
+    # Create BNADataStore and inject the S3 store as the cache
+    bna_store = datastore.BNADataStore(
+        pathlib.Path(file_utils.get_user_cache_dir()),
+        datastore.CacheType.USER_CACHE,
+        mirror=mirror,
+    )
+    bna_store.cache = s3_store
+
+    # Run the same download loop, passing cache_only=True
+    asyncio.run(_run_downloads(bna_store, cache_only=True))
+
+```
+
+- `_run_downloads` is extracted from the existing `main()` body so both `local`
+  and `s3` subcommands can reuse it. It should allow passing a `bna_store`
+  instance and an `aiohttp.ClientSession` context.
+
+### 2) Minimal additions to `datastore.py`
+
+- No code changes required to `datastore.py` for the first iteration. The design
+  relies on runtime injection of `bna_store.cache`.
+
+### 3) Error cleanup helper
+
+- Add a helper (in `utils/cache-warmer.py`) to delete partial S3 objects using
+  `exporter.get_s3_bucket(bucket).Object(key).delete()`.
+
+## Testing & Verification
+
+- Manual integration test steps:
+
+```bash
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_REGION=us-east-1
+uv run python utils/cache-warmer.py s3 --bucket my-test-bucket
+```
+
+- Verify keys like `census/tl_2020_06_tabblock20.zip` exist in the bucket.
+- Simulate failure by temporarily revoking credentials during a run and confirm
+  partial objects are removed and process exits non-zero.
+
+## Rationale & Alternatives
+
+- Injection vs modifying `datastore`: injection keeps change surface small and
+  is reversible. It preserves the single source of download logic.
+- Using `obstore` for streaming keeps code consistent with other store
+  interactions in the project; using `boto3` directly for cleanup covers any
+  differences in `obstore` store behavior.
+
+## Next code tasks (what to implement next)
+
+1. Extract `_run_downloads(bna_store, cache_only)` helper from
+   `utils/cache-warmer.py`.
+2. Add `typer` subcommand wiring and implement `s3` as described.
+3. Add cleanup logic using `boto3` on exceptions.
+4. Add unit/integration verification steps to `tasks.md`.

--- a/specs/0001-cache-warmer-s3/requirements.md
+++ b/specs/0001-cache-warmer-s3/requirements.md
@@ -1,0 +1,108 @@
+# Requirements: Cache-Warmer S3
+
+## Purpose
+
+Allow the existing `cache-warmer` utility to populate an AWS S3 bucket directly
+from upstream sources (no local cache writes) so downstream processes can read
+pre-warmed artifacts from S3.
+
+## EARS Requirements
+
+### Ubiquitous Requirements
+
+- The system SHALL add a new `cache-warmer s3` capability to populate AWS S3
+  directly from upstream artifact sources.
+- The system SHALL reuse download logic in
+  `brokenspoke_analyzer/core/datastore.py` and SHALL NOT reimplement source
+  fetch logic.
+- The system SHALL use `obstore` for object storage operations and SHALL rely on
+  its default retry behavior.
+- The system SHALL organize uploaded objects under top-level prefixes by data
+  type:
+  - `census/…`
+  - `lodes/…`
+  - `osm/…`
+  - `state-speed-limits/…`
+  - `city-speed-limits/…`
+- The system SHALL log progress and errors using existing Rich/loguru
+  conventions.
+- The system SHALL work in local development, CI, and Docker contexts using only
+  standard AWS environment variables.
+- The system SHALL not support `--prefix` or a dry-run/preflight report in this
+  first iteration.
+
+### Event-Driven Requirements
+
+- WHEN `cache-warmer s3` is invoked, the system SHALL require a `--bucket`
+  argument and SHALL accept `--mirror` as an optional passthrough to existing
+  mirror handling in the datastore.
+- WHEN `cache-warmer` is invoked with no command, the system SHALL display the
+  CLI help screen and SHALL not start warming data.
+- WHEN an artifact is streamed from its original source, the system SHALL write
+  it directly into S3 using `obstore`-compatible uploads without writing any
+  local cache files.
+- WHEN an artifact is uploaded to S3, the system SHALL use the key format
+  `<data-type>/<filename>` (for example, `census/fips-12345.json`).
+- WHEN an upload or download error occurs for an artifact, the system SHALL
+  delete any partially created S3 object for that artifact, log the cause, and
+  exit non-zero.
+
+### State-Driven Requirements
+
+- WHILE `cache-warmer s3` is running, the system SHALL stream each artifact
+  sequentially and avoid local persistence.
+- WHILE `BNADataStore.cache` is routed to an S3-backed `obstore` store, the
+  system SHALL let `fetch_to_cache` write directly to S3.
+
+## Traceable Requirements
+
+- FR-1: The `cache-warmer s3` subcommand SHALL require `--bucket` and SHALL
+  accept optional `--mirror`.
+- FR-2: The system SHALL stream each artifact from source directly into S3 using
+  `obstore`-compatible uploads and SHALL avoid local files.
+- FR-3: The system SHALL write S3 objects using the key format
+  `<data-type>/<filename>`.
+- FR-4: The system SHALL use AWS credentials from environment variables:
+  `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, and optional
+  `AWS_SESSION_TOKEN`.
+- FR-5: On any error, the system SHALL delete partial S3 objects, log the cause,
+  and exit non-zero.
+- FR-6: The system SHALL log progress and errors using existing logging
+  conventions.
+- NFR-1: The system SHALL minimize changes to
+  `brokenspoke_analyzer/core/datastore.py` and SHALL prefer assigning an
+  S3-backed `obstore` store to `BNADataStore.cache` at runtime for the `s3`
+  subcommand.
+- NFR-2: The system SHALL keep operations asynchronous (asyncio) and sequential
+  per artifact.
+- NFR-3: The system SHALL work in local dev, CI, and Docker contexts without
+  special configuration other than AWS environment variables.
+- NFR-4: The system SHALL not implement dry-run or preflight reporting in this
+  first iteration.
+
+## Acceptance Criteria
+
+- AC-1: WHEN `cache-warmer s3 --bucket my-bucket` is executed, the system SHALL
+  upload the same set of artifacts as local warming under the expected prefixes
+  without writing any local files.
+- AC-2: WHEN a network failure is simulated mid-download, the system SHALL leave
+  no partial object in S3 and SHALL exit non-zero with a clear error.
+- AC-3: The system SHALL log each artifact upload completion and any errors.
+- AC-4: The implementation SHALL reuse datastore download helpers and confine
+  changes to the reviewed runtime behavior.
+
+## Constraints & Assumptions
+
+- C1: The system SHALL reuse all download/fetch logic from
+  `brokenspoke_analyzer/core/datastore.py`.
+- C2: The system SHALL prefer `obstore` for uploads and its default retry
+  policy.
+- A1: The system SHALL route `BNADataStore.cache` to an S3 `obstore` store (for
+  example, `from_url("s3://bucket")`) during `s3` runs so `fetch_to_cache`
+  writes directly to S3.
+
+## Out-of-Scope (first iteration)
+
+- Support for Cloudflare R2, GCS, or other storage backends.
+- `--prefix` or configurable bucket prefixing.
+- Dry-run or summary reports.

--- a/specs/0001-cache-warmer-s3/tasks.md
+++ b/specs/0001-cache-warmer-s3/tasks.md
@@ -1,0 +1,111 @@
+# Tasks: Cache-Warmer S3
+
+This file contains the ordered implementation tasks and verification steps to
+add an `s3` subcommand to the cache-warmer utility. The goal is to stream
+artifacts directly into an S3 bucket using the existing `BNADataStore` download
+pipeline.
+
+## Summary
+
+- Implement `cache-warmer s3 --bucket <name>` that streams artifacts into S3 (no
+  local writes).
+- Reuse `brokenspoke_analyzer/core/datastore.py` download helpers by injecting
+  an `obstore` S3 store into `BNADataStore.cache` at runtime.
+
+## Tasks
+
+- [ ] 1 — Extract `_run_downloads(bna_store, cache_only: bool)`
+  - [ ] 1.1 — Move the current download loop from `utils/cache-warmer.py:main()`
+        into a reusable async helper.
+  - [ ] 1.2 — Implement signature:
+
+    ```py
+    async def _run_downloads(
+      bna_store: BNADataStore,
+      *,
+      cache_only: bool = True,
+      ) -> None
+    ```
+
+  - [ ] 1.3 — Ensure the helper creates and uses an `aiohttp.ClientSession`,
+        iterates the same sources in the same order, and raises on first error.
+
+- [ ] 2 — Convert `utils/cache-warmer.py` into a `typer` app
+  - [ ] 2.1 — Add `app = typer.Typer()`.
+  - [ ] 2.2 — Add `local` subcommand that constructs `BNADataStore` as today and
+        calls `_run_downloads`.
+  - [ ] 2.3 — Configure the CLI so that `uv run python utils/cache-warmer.py` with
+        no subcommand displays the help screen and does not start warming.
+  - [ ] 2.4 — Keep compatibility so the original behavior is preserved when a
+        subcommand is explicitly provided.
+
+- [ ] 3 — Implement `s3` subcommand
+  - [ ] 3.1 — Add CLI: `cache-warmer s3 --bucket <bucket> [--mirror <mirror>]`.
+  - [ ] 3.2 — Create an S3 `obstore` store via
+        `exporter.create_s3_store(bucket)`.
+  - [ ] 3.3 — Instantiate `BNADataStore(..., mirror=mirror)` and set
+        `bna_store.cache = s3_store`.
+  - [ ] 3.4 — Call `_run_downloads(bna_store, cache_only=True)`.
+
+- [ ] 4 — Add per-artifact failure cleanup
+  - [ ] 4.1 — Wrap the call that triggers a single artifact download (the
+        `fetch_to_cache` invocation) with try/except in `_run_downloads` or a
+        small wrapper.
+  - [ ] 4.2 — On exception, compute the S3 key used for the artifact (same
+        `path` passed to `fetch_to_cache`).
+  - [ ] 4.3 — Remove partial objects using `obstore` cleanup APIs if available,
+        and only use `boto3` as a documented fallback if obstore cannot delete
+        the partially created object reliably.
+  - [ ] 4.4 — Log the error (loguru/rich) and exit/raise.
+
+- [ ] 5 — Checkpoint: validate CLI and runtime wiring
+  - [ ] 5.1 — Confirm `cache-warmer local` and `cache-warmer s3` subcommands
+        exist and parse expected options.
+  - [ ] 5.2 — Confirm `BNADataStore.cache` can be reassigned to an S3-backed
+        `obstore` store.
+  - [ ] 5.3 — Review that `boto3` is not introduced unless required for cleanup,
+        and document the fallback decision.
+
+- [ ] 6 — Tests & verification
+  - [ ] 6.1 — Add a `just` task `cache-warmer-s3` to invoke the script with
+        `uv`.
+  - [ ] 6.2 — Add automated tests or a documentable manual verification path for
+        S3 upload completion, partial-object cleanup, and non-zero exit on
+        failure.
+
+## Verification commands
+
+Export credentials and run the s3 warmer:
+
+```bash
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_REGION=us-east-1
+uv run python utils/cache-warmer.py s3 --bucket my-test-bucket
+```
+
+Check bucket keys:
+
+```bash
+aws s3 ls s3://my-test-bucket/ --recursive | head -n 50
+```
+
+Simulate failure test (manual): start the process and revoke credentials or send
+SIGTERM mid-download, confirm partial key removed and process exit code != 0.
+
+## Notes & decisions
+
+- Prefer `obstore` for streaming uploads and cleanup.
+- `boto3` SHALL NOT be used unless no other viable path exists for removing
+  partially created S3 objects; if `boto3` is used, document the decision and
+  the missing obstore capability.
+- No `--prefix` support in this iteration; top-level prefixes come from
+  `SourceAdapter.subpath`.
+- No dry-run option in first iteration.
+
+## Next steps (after tasks.md)
+
+1. Implement `_run_downloads` and the `typer` subcommands in
+   `utils/cache-warmer.py`.
+2. Implement cleanup logic and test manually against a test bucket.
+3. Add CI/integration test hooks if desired.

--- a/tests/test_cache_warmer.py
+++ b/tests/test_cache_warmer.py
@@ -1,0 +1,56 @@
+"""Tests for the cache warmer utility."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+from obstore.store import MemoryStore
+
+from brokenspoke_analyzer.core import datastore
+
+
+class DummyContent:
+    def __init__(self) -> None:
+        self._chunks = [b"hello", RuntimeError("stream failed")]
+
+    async def iter_chunked(self, _size: int):
+        for chunk in self._chunks:
+            if isinstance(chunk, Exception):
+                raise chunk
+            yield chunk
+
+
+class DummyResponse:
+    def __init__(self) -> None:
+        self.content = DummyContent()
+
+    async def __aenter__(self) -> "DummyResponse":
+        return self
+
+    async def __aexit__(self, *_: object) -> bool:
+        return False
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class DummySession:
+    def get(self, _url: str) -> DummyResponse:
+        return DummyResponse()
+
+
+@pytest.mark.asyncio
+async def test_fetch_to_cache_removes_partial_object(tmp_path: pathlib.Path) -> None:
+    bna_store = datastore.BNADataStore(tmp_path, datastore.CacheType.USER_CACHE)
+    bna_store.cache = MemoryStore()
+    session = DummySession()
+
+    with pytest.raises(RuntimeError, match="stream failed"):
+        await bna_store.fetch_to_cache(
+            session,
+            "https://example.com/test.txt",
+            "census/test.txt",
+        )
+
+    assert not bna_store.is_cached("census/test.txt")

--- a/utils/cache-warmer.py
+++ b/utils/cache-warmer.py
@@ -21,13 +21,16 @@ from __future__ import annotations
 import asyncio
 import os
 import pathlib
+from typing import Annotated
 
 import aiohttp
 import rich
+import typer
 
 from brokenspoke_analyzer.cli import root
 from brokenspoke_analyzer.core import (
     datastore,
+    exporter,
     file_utils,
 )
 from brokenspoke_analyzer.pyrosm.data import geofabrik
@@ -37,40 +40,33 @@ from brokenspoke_analyzer.pyrosm.data import geofabrik
 os.environ["DC_STATEHOOD"] = "1"
 import us
 
+app = typer.Typer(no_args_is_help=True)
 
-async def main() -> None:
-    """Define the main function."""
-    # Disable logging.
-    root._verbose_callback(0)
 
-    # Prepare the Rich output.
+async def _run_downloads(
+    bna_store: datastore.BNADataStore,
+    *,
+    cache_only: bool = True,
+) -> None:
+    """Run the download pipeline using the provided BNADataStore."""
     console = rich.get_console()
 
-    cache_only = True
-    bna_store = datastore.BNADataStore(
-        pathlib.Path(file_utils.get_user_cache_dir()),
-        datastore.CacheType.USER_CACHE,
-    )
-
-    # Start the downloads.
     async with aiohttp.ClientSession() as session:
-        # Download the single files first.
         console.log("Downloading state speed limits")
         await bna_store.download_state_speed_limits(session, cache_only=cache_only)
         console.log("Downloading city speed limits")
         await bna_store.download_city_speed_limits(session, cache_only=cache_only)
 
-        # Download the state-specific files.
         for i, (fips, abbr) in enumerate(us.states.mapping("fips", "abbr").items()):
-            # Skip US territories.
-            # They are part of the US but we don't have any data for them.
             if fips in {"60", "66", "69", "72", "78"}:
                 continue
             with console.status(
                 f"[{i + 1}/{len(us.states.STATES)}] Processing {abbr} ({fips})",
             ):
                 console.log(f"Downloading US Census data for {abbr} ({fips})")
-                await bna_store.download_2020_census_blocks(session, fips)
+                await bna_store.download_2020_census_blocks(
+                    session, fips, cache_only=cache_only
+                )
                 console.log(f"Downloading LODES data for {abbr} ({fips})")
                 await bna_store.download_lodes_data(
                     session,
@@ -78,12 +74,9 @@ async def main() -> None:
                     cache_only=cache_only,
                 )
 
-        # Download the OSM data for the specified regions.
         osm_regions = []
-        # Add the US states.
         osm_regions.extend(geofabrik.USA()._sources.keys())
 
-        # Start the downloads.
         for i, region in enumerate(osm_regions):
             with console.status(
                 f"[{i + 1}/{len(osm_regions)}] Processing OSM {region}",
@@ -96,5 +89,54 @@ async def main() -> None:
                 )
 
 
+def _build_store(mirror: str | None) -> datastore.BNADataStore:
+    return datastore.BNADataStore(
+        pathlib.Path(file_utils.get_user_cache_dir()),
+        datastore.CacheType.USER_CACHE,
+        mirror=mirror,
+    )
+
+
+def _build_s3_store(bucket: str, mirror: str | None) -> datastore.BNADataStore:
+    store = _build_store(mirror)
+    store.cache = exporter.create_s3_store(bucket)
+    return store
+
+
+@app.command("local")
+def local(
+    mirror: Annotated[
+        str | None, typer.Option("--mirror", help="Optional mirror URL.")
+    ] = None,
+) -> None:
+    """Warm the local user cache using the existing cache-warmer pipeline."""
+    root._verbose_callback(0)
+    bna_store = _build_store(mirror)
+    asyncio.run(_run_downloads(bna_store, cache_only=True))
+
+
+@app.command("s3")
+def s3(
+    bucket: Annotated[
+        str,
+        typer.Option(..., "--bucket", help="Target S3 bucket name."),
+    ],
+    mirror: Annotated[
+        str | None, typer.Option("--mirror", help="Optional mirror URL.")
+    ] = None,
+) -> None:
+    """Warm an S3 bucket directly from upstream artifact sources."""
+    root._verbose_callback(0)
+    bna_store = _build_s3_store(bucket, mirror)
+    asyncio.run(_run_downloads(bna_store, cache_only=True))
+
+
+def main() -> None:
+    """Run the default cache-warmer behavior for backwards compatibility."""
+    root._verbose_callback(0)
+    bna_store = _build_store(mirror=None)
+    asyncio.run(_run_downloads(bna_store, cache_only=True))
+
+
 if __name__ == "__main__":
-    asyncio.run(main())
+    app()


### PR DESCRIPTION
Adds the ability for cache-warmer to populate an S3 bucket directly
without having to downloading the files locally.

Items:
- Prepares the  specs for S3 support to cache-warmer.
- Implements the feature with copilot.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>