### PR TITLE
Use Datastore To Fetch City Boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ pip-log.txt
 profile.svg
 results/
 results/*
+reviews/
 sdist/
 target/
 var/

--- a/brokenspoke_analyzer/cli/prepare.py
+++ b/brokenspoke_analyzer/cli/prepare.py
@@ -1,7 +1,6 @@
 """Define the prepare sub-command."""
 
 import asyncio
-import logging
 import pathlib
 
 import aiohttp
@@ -10,11 +9,6 @@ import pycountry
 import rich
 import typer
 from loguru import logger
-from tenacity import (
-    Retrying,
-    before_log,
-    stop_after_attempt,
-)
 
 from brokenspoke_analyzer.cli import common
 from brokenspoke_analyzer.core import (
@@ -112,41 +106,16 @@ async def prepare_(  # noqa: PLR0915
     worldpop_year: int,
 ) -> None:
     """Prepare and kicks off the analysis."""
-    # Compute the city slug.
-    _, _, slug = analysis.osmnx_query(country, city, region)
-
-    # Prepare the data directory.
-    data_dir /= slug
-    data_dir.mkdir(parents=True, exist_ok=True)
-    logger.info(f"{data_dir=}")
-
     # Prepare the Rich output.
     console = rich.get_console()
 
-    # Create retrier instance to use for all downloads.
-    retryer = Retrying(
-        stop=stop_after_attempt(retries),
-        reraise=True,
-        before=before_log(logger, logging.DEBUG),
-    )
+    # Compute the OSM queries and city slug.
+    structured_query, text_query, slug = analysis.osmnx_query(country, city, region)
 
-    # Retrieve city boundaries.
-    console.log(
-        f"[green]Querying OSM to retrieve {city} boundaries...",
-    )
-    slug = retryer(
-        analysis.retrieve_city_boundaries,
-        data_dir,
-        country,
-        city,
-        region,
-        fips_code,
-    )
-    boundary_file = data_dir / f"{slug}.shp"
-
-    # Download the OSM region file.
-    state_abbrev, state_fips, _ = analysis.derive_state_info(region)
-    osm_region = region or country
+    # Prepare the data directory for custom downloads.
+    data_dir /= slug
+    data_dir.mkdir(parents=True, exist_ok=True)
+    logger.info(f"{data_dir=}")
 
     # Prepare the caching strategy.
     caching_strategy = datastore.CacheType.USER_CACHE
@@ -155,12 +124,28 @@ async def prepare_(  # noqa: PLR0915
     elif cache_dir:
         caching_strategy = datastore.CacheType.CUSTOM
 
+    # Prepare the data store.
     bna_store = datastore.BNADataStore(
         data_dir,
         caching_strategy,
         mirror=mirror,
         custom_dir=cache_dir,
     )
+
+    # Download the city boundaries.
+    console.log(f"[green]Fetching city boundaries for {city}...")
+    with console.status("Downloading..."):
+        await bna_store.download_city_boundaries(
+            retries,
+            structured_query,
+            text_query,
+            slug,
+            fips_code=fips_code,
+        )
+
+    # Derive some information from the input.
+    state_abbrev, state_fips, _ = analysis.derive_state_info(region)
+    osm_region = region or country
 
     async with aiohttp.ClientSession() as session:
         console.log(
@@ -185,6 +170,7 @@ async def prepare_(  # noqa: PLR0915
             # Create synthetic population.
             console.log("[green]Preparing synthetic population...")
             cell_size = (block_size, block_size)
+            boundary_file = data_dir / f"{slug}.geojson"
             city_boundaries_gdf = gpd.read_file(boundary_file)
             synthetic_population = analysis.create_synthetic_population(
                 city_boundaries_gdf, *cell_size, population=block_population

--- a/brokenspoke_analyzer/core/analysis.py
+++ b/brokenspoke_analyzer/core/analysis.py
@@ -11,6 +11,7 @@ import geopandas as gpd
 import numpy as np
 import pygris
 import shapely
+from geopandas.geodataframe import GeoDataFrame
 from loguru import logger
 from osmnx import (
     geocoder,
@@ -148,26 +149,19 @@ def ensure_gdf_class_boundary(gdf: gpd.GeoDataFrame) -> None:
 
 
 def retrieve_city_boundaries(
-    output: pathlib.Path,
-    country: str,
-    city: str,
-    state: str | None = None,
+    structured_query: dict[str, str],
+    text_query: str,
     fips_code: str | None = None,
-) -> str:
+) -> GeoDataFrame:
     """
     Retrieve the city boundaries and save them as Shapefile and GeoJSON.
 
     :return: the slugified query used to retrieve the city boundaries.
     """
-    # Retrieve the geodataframe.
-    structured_query, q, slug = osmnx_query(country, city, state)
-    # Download boundaries from Census Bureau for US places with FIPS Code
-    # with OSM as a fallback for other places.
     if fips_code is not None and fips_code != common.DEFAULT_CITY_FIPS_CODE:
-        cache_enabled = os.getenv("BNA_PYGRIS_CACHE", "1") == "1"
         places = pygris.places(
             state=fips_code[:2],
-            cache=cache_enabled,
+            cache=False,
             year=common.DEFAULT_PYGRIS_YEAR,
         )
         city_gdf = places[places["PLACEFP"] == fips_code[2:]]
@@ -178,35 +172,29 @@ def retrieve_city_boundaries(
             )
             county_subdivisions = pygris.county_subdivisions(
                 state=fips_code[:2],
-                cache=cache_enabled,
+                cache=False,
                 year=common.DEFAULT_PYGRIS_YEAR,
             )
             city_gdf = county_subdivisions[
                 county_subdivisions["COUSUBFP"] == fips_code[2:]
             ]
     else:
-        settings.use_cache = os.getenv("BNA_OSMNX_CACHE", "1") == "1"
-        # Prepare the query.
+        settings.use_cache = False
         logger.debug(f"Query used to retrieve the boundaries: {structured_query}")
-
         try:
             city_gdf = geocoder.geocode_to_gdf(structured_query)
             ensure_gdf_class_boundary(city_gdf)
         except (TypeError, InsufficientResponseError):
-            city_gdf = geocoder.geocode_to_gdf(q)
+            city_gdf = geocoder.geocode_to_gdf(text_query)
             ensure_gdf_class_boundary(city_gdf)
 
         # Remove the display_name series to ensure there are no international
         # characters in the dataframe. The import will fail if the analyzer finds
         # non US characters.
         # https://github.com/PeopleForBikes/brokenspoke-analyzer/issues/24
-        city_gdf.drop("display_name", axis=1)
+        city_gdf.drop("display_name", axis=1, inplace=True)
 
-    # Export the boundaries.
-    city_gdf.to_file(output / f"{slug}.shp", encoding="utf-8")
-    city_gdf.to_file(output / f"{slug}.geojson")
-
-    return slug
+    return city_gdf
 
 
 # pylint: disable=too-many-locals

--- a/brokenspoke_analyzer/core/datasource.py
+++ b/brokenspoke_analyzer/core/datasource.py
@@ -218,14 +218,10 @@ class WorldPopAdapter(SourceAdapter):
     @property
     def urls(self) -> abc.Sequence[yarl.URL]:
         """Return the source data URLs."""
-        return [
-            self.source_url
-            / str(self.year)
-            / self.country
-            / "v1/1km_ua/constrained"
-            / str(f)
-            for f in self.files
-        ]
+        base_url = (
+            self.source_url / str(self.year) / self.country / "v1/1km_ua/constrained"
+        )
+        return [base_url / str(f) for f in self.files]
 
     def prepare(self, datastore: pathlib.Path) -> None:
         """Prepare the data files."""

--- a/brokenspoke_analyzer/core/datastore.py
+++ b/brokenspoke_analyzer/core/datastore.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import enum
+import logging
 import pathlib
 from typing import TYPE_CHECKING
 
@@ -12,8 +13,14 @@ from obstore import exceptions as obstore_exceptions
 from obstore.store import (
     from_url,
 )
+from tenacity import (
+    Retrying,
+    before_log,
+    stop_after_attempt,
+)
 
 from brokenspoke_analyzer.core import (
+    analysis,
     datasource,
     downloader,
     file_utils,
@@ -125,14 +132,14 @@ class BNADataStore:
         destination: str | None = None,
     ) -> None:
         """Copy a file from the cache to the store."""
-        if not exists(self.cache, path):
+        if not self.is_cached(path):
             raise FileNotFoundError(f"{path} was not found in the cache")
 
         # Change the destination path if we do not want it to match the source path.
         destination_path = destination or path
 
         # Copy the file if it does not already exist in the store.
-        if exists(self.store, destination_path):
+        if self.is_stored(destination_path):
             return
         res = await self.cache.get_async(path)
         await self.store.put_async(destination_path, res)
@@ -241,6 +248,28 @@ class BNADataStore:
         if not cache_only:
             await self.store.delete_async(source.subpath)
 
+    async def put_file(
+        self,
+        path: str,
+        file: pathlib.Path,
+        *,
+        cache_only: bool = False,
+    ) -> None:
+        """Put a file into the store."""
+        logger.debug(f"Putting file {path} into the BNA store from {file}")
+
+        # Check whether the file already exists in the cache.
+        if not self.is_cached(path):
+            logger.debug(f"Putting file {file} into the cache at {path}")
+            await self.cache.put_async(path, file)
+        else:
+            logger.debug(f"{path} was cached")
+
+        # Put the file in the store if needed.
+        if not cache_only:
+            logger.debug(f"Putting file {file} into the store at {path}")
+            await self.copy_to_store(path)
+
     async def download_state_speed_limits(
         self,
         session: aiohttp.ClientSession,
@@ -325,3 +354,62 @@ class BNADataStore:
         s = datasource.OSMAdapter(region, self.mirror)
         await self.fetch_from_source(session, s, cache_only=cache_only)
         return pathlib.Path(s.urls[0].name)
+
+    async def download_city_boundaries(
+        self,
+        retries: int,
+        structured_query: dict[str, str],
+        text_query: str,
+        slug: str,
+        fips_code: str | None = None,
+    ) -> None:
+        """Retrieve the city boundaries file."""
+        # Create retrier instance to use for all direct downloads.
+        retryer = Retrying(
+            stop=stop_after_attempt(retries),
+            reraise=True,
+            before=before_log(logger, logging.DEBUG),
+        )
+
+        # Retrieve the boundary file.
+        extensions = {".geojson", ".cpg", ".dbf", ".prj", ".shp", ".shx"}
+        boundary_file_name_stem = pathlib.Path(slug)
+        if all(
+            self.is_cached(str(boundary_file_name_stem.with_suffix(ext)))
+            for ext in extensions
+        ):
+            logger.debug("Boundary files are cached. Copying them to the store...")
+            for ext in extensions:
+                await self.copy_to_store(str(boundary_file_name_stem.with_suffix(ext)))
+            return
+
+        # Retrieve the city boundaries.
+        boundary_gdf = retryer(
+            analysis.retrieve_city_boundaries,
+            structured_query=structured_query,
+            text_query=text_query,
+            fips_code=fips_code,
+        )
+
+        # Prepare the "boundaries" folder in the cache if needed.
+        prefix = self.cache.prefix / "boundaries"
+        prefix.mkdir(parents=True, exist_ok=True)
+        logger.debug(f"{prefix=}")
+
+        # Prepare the shapefile.
+        boundary_file = prefix / boundary_file_name_stem
+        boundary_shapefile = boundary_file.with_suffix(".shp")
+        logger.debug(f"Copying boundary file to {boundary_shapefile}")
+        boundary_gdf.to_file(boundary_shapefile, encoding="utf-8")
+
+        # Preparing the geojosn file.
+        boundary_geojson_file = boundary_file.with_suffix(".geojson")
+        logger.debug(f"Copying boundary geojson file to {boundary_geojson_file}")
+        boundary_gdf.to_file(boundary_geojson_file)
+
+        # Put the files into the store.
+        for ext in extensions:
+            await self.put_file(
+                str(boundary_file_name_stem.with_suffix(ext)),
+                prefix / boundary_file.with_suffix(ext),
+            )


### PR DESCRIPTION
Updates the logic to leverage the Datastore to fetch the city boundaries
file and cache them.

Fixes PeopleForBikes/brokenspoke-analyzer#1141

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
