### PR TITLE
Add WorldPop support for all/supported countries

### DIFF
--- a/brokenspoke_analyzer/cli/common.py
+++ b/brokenspoke_analyzer/cli/common.py
@@ -1,6 +1,10 @@
 """Defines the values shared amongst the CLI modules."""
 
 import pathlib
+from datetime import (
+    UTC,
+    datetime,
+)
 from typing import Annotated
 
 import typer
@@ -22,6 +26,7 @@ DEFAULT_LODES_YEAR = 2022
 DEFAULT_MAX_TRIP_DISTANCE = 2680
 DEFAULT_PYGRIS_YEAR = 2024
 DEFAULT_RETRIES = 2
+DEFAULT_WORLDPOP_YEAR: int = datetime.now(tz=UTC).year
 
 # Default Typer Arguments/Options.
 BlockPopulation = Annotated[
@@ -106,3 +111,7 @@ SpeedLimit = Annotated[
 ]
 State = Annotated[str | None, typer.Argument(help="US state")]
 WithBundle = Annotated[bool, typer.Option(help="bundle all the files in a zip archive")]
+WorldPopYear = Annotated[
+    int,
+    typer.Option(help="year to use to retrieve WorldPop data"),
+]

--- a/brokenspoke_analyzer/cli/prepare.py
+++ b/brokenspoke_analyzer/cli/prepare.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import pathlib
+import pycountry
 
 import aiohttp
 import geopandas as gpd
@@ -175,13 +176,9 @@ async def prepare_(  # noqa: PLR0915
 
     # Perform some specific operations for non-US cities.
     if state_fips == runner.NON_US_STATE_FIPS:
-        if country == "Canada":
-            country_iso = country[:3].upper()
-            async with aiohttp.ClientSession() as session:
-                console.log("[green]Fetching WorldPop (2021) data...")
-                with console.status("Downloading..."):
-                    await bna_store.download_worldpop(session, country_iso)
-        else:
+        try:
+            country_iso = pycountry.countries.search_fuzzy('country')[0].alpha_3
+        except LookupError:
             # Create synthetic population.
             console.log("[green]Preparing synthetic population...")
             cell_size = (block_size, block_size)
@@ -189,11 +186,14 @@ async def prepare_(  # noqa: PLR0915
             synthetic_population = analysis.create_synthetic_population(
                 city_boundaries_gdf, *cell_size, population=block_population
             )
-
             # Simulate the census blocks.
             console.log("[green]Simulating census blocks...")
             analysis.simulate_census_blocks(data_dir, synthetic_population)
-
+        else:
+            async with aiohttp.ClientSession() as session:
+                console.log("[green]Fetching WorldPop (2021) data...")
+                with console.status("Downloading..."):
+                    await bna_store.download_worldpop(session, country_iso)
         # Change the speed limit.
         console.log(
             f"[green]Adjusting default city speed limit to {city_speed_limit} km/h...",

--- a/brokenspoke_analyzer/cli/prepare.py
+++ b/brokenspoke_analyzer/cli/prepare.py
@@ -3,10 +3,10 @@
 import asyncio
 import logging
 import pathlib
-import pycountry
 
 import aiohttp
 import geopandas as gpd
+import pycountry
 import rich
 import typer
 from loguru import logger
@@ -45,6 +45,7 @@ def prepare_cmd(
     lodes_year: common.LODESYear = None,
     mirror: common.Mirror = None,
     retries: common.Retries = common.DEFAULT_RETRIES,
+    worldpop_year: common.WorldPopYear = common.DEFAULT_WORLDPOP_YEAR,
     *,
     no_cache: common.NoCache = False,
 ) -> None:
@@ -88,6 +89,7 @@ def prepare_cmd(
             no_cache=bool(no_cache),
             region=region or None,
             retries=retries,
+            worldpop_year=worldpop_year,
         ),
     )
 
@@ -107,6 +109,7 @@ async def prepare_(  # noqa: PLR0915
     lodes_year: int | None,
     mirror: str | None,
     region: str | None,
+    worldpop_year: int,
 ) -> None:
     """Prepare and kicks off the analysis."""
     # Compute the city slug.
@@ -177,7 +180,7 @@ async def prepare_(  # noqa: PLR0915
     # Perform some specific operations for non-US cities.
     if state_fips == runner.NON_US_STATE_FIPS:
         try:
-            country_iso = pycountry.countries.search_fuzzy('country')[0].alpha_3
+            country_iso = pycountry.countries.search_fuzzy("country")[0].alpha_3
         except LookupError:
             # Create synthetic population.
             console.log("[green]Preparing synthetic population...")
@@ -191,9 +194,11 @@ async def prepare_(  # noqa: PLR0915
             analysis.simulate_census_blocks(data_dir, synthetic_population)
         else:
             async with aiohttp.ClientSession() as session:
-                console.log("[green]Fetching WorldPop (2021) data...")
+                console.log(f"[green]Fetching WorldPop ({worldpop_year}) data...")
                 with console.status("Downloading..."):
-                    await bna_store.download_worldpop(session, country_iso)
+                    await bna_store.download_worldpop(
+                        session, country_iso, worldpop_year
+                    )
         # Change the speed limit.
         console.log(
             f"[green]Adjusting default city speed limit to {city_speed_limit} km/h...",

--- a/brokenspoke_analyzer/cli/run.py
+++ b/brokenspoke_analyzer/cli/run.py
@@ -43,6 +43,7 @@ def run(
     s3_dir: pathlib.Path | None = None,
     with_export: exporter.Exporter = exporter.Exporter.local,
     with_parts: common.ComputeParts = common.DEFAULT_COMPUTE_PARTS,
+    worldpop_year: common.WorldPopYear = common.DEFAULT_WORLDPOP_YEAR,
     *,
     no_cache: common.NoCache = False,
     with_bundle: bool = False,
@@ -71,5 +72,6 @@ def run(
             with_bundle=with_bundle,
             with_export=with_export,
             with_parts=with_parts,
+            worldpop_year=worldpop_year,
         ),
     )

--- a/brokenspoke_analyzer/cli/run_with.py
+++ b/brokenspoke_analyzer/cli/run_with.py
@@ -48,6 +48,7 @@ def compose(
     s3_bucket: str | None = None,
     with_export: exporter.Exporter = exporter.Exporter.local,
     with_parts: common.ComputeParts = common.DEFAULT_COMPUTE_PARTS,
+    worldpop_year: common.WorldPopYear = common.DEFAULT_WORLDPOP_YEAR,
     *,
     no_cache: common.NoCache = False,
     with_bundle: bool = False,
@@ -84,6 +85,7 @@ def compose(
                 with_bundle=with_bundle,
                 with_export=with_export,
                 with_parts=with_parts,
+                worldpop_year=worldpop_year,
             ),
         )
     finally:
@@ -124,6 +126,7 @@ async def run_(  # noqa: C901, PLR0912, PLR0915
     with_bundle: bool = False,
     with_export: exporter.Exporter = exporter.Exporter.local,
     with_parts: common.ComputeParts = common.DEFAULT_COMPUTE_PARTS,
+    worldpop_year: common.WorldPopYear = common.DEFAULT_WORLDPOP_YEAR,
 ) -> pathlib.Path | None:
     """Run an analysis."""
     # Make mypy happy.
@@ -176,6 +179,7 @@ async def run_(  # noqa: C901, PLR0912, PLR0915
         no_cache=bool(no_cache),
         region=region,
         retries=retries,
+        worldpop_year=worldpop_year,
     )
 
     # Import.

--- a/brokenspoke_analyzer/core/analysis.py
+++ b/brokenspoke_analyzer/core/analysis.py
@@ -16,6 +16,7 @@ from osmnx import (
     geocoder,
     settings,
 )
+from osmnx._errors import InsufficientResponseError
 from slugify import slugify
 
 from brokenspoke_analyzer.cli import common
@@ -191,7 +192,7 @@ def retrieve_city_boundaries(
         try:
             city_gdf = geocoder.geocode_to_gdf(structured_query)
             ensure_gdf_class_boundary(city_gdf)
-        except TypeError:
+        except (TypeError, InsufficientResponseError):
             city_gdf = geocoder.geocode_to_gdf(q)
             ensure_gdf_class_boundary(city_gdf)
 

--- a/brokenspoke_analyzer/core/datasource.py
+++ b/brokenspoke_analyzer/core/datasource.py
@@ -181,7 +181,7 @@ class WorldPopAdapter(SourceAdapter):
     def __init__(
         self,
         country: str,
-        year: str,
+        year: int,
         mirror: str | None = None,
     ) -> None:
         """
@@ -220,7 +220,7 @@ class WorldPopAdapter(SourceAdapter):
         """Return the source data URLs."""
         return [
             self.source_url
-            / self.year
+            / str(self.year)
             / self.country
             / "v1/1km_ua/constrained"
             / str(f)

--- a/brokenspoke_analyzer/core/datastore.py
+++ b/brokenspoke_analyzer/core/datastore.py
@@ -302,14 +302,14 @@ class BNADataStore:
         self,
         session: aiohttp.ClientSession,
         country: str,
-        year: str = "2026",
+        year: int,
         *,
         cache_only: bool = False,
     ) -> None:
         """
         Download a WorldPop 1km resolution geoTIFF for a specific country.
 
-        Default year to 2026 to match current year
+        Default year to current year
         """
         s = datasource.WorldPopAdapter(country, year, self.mirror)
         await self.fetch_from_source(session, s, cache_only=cache_only)

--- a/docs/source/commands.md
+++ b/docs/source/commands.md
@@ -232,6 +232,11 @@ values in the options.
 
     Defaults to 2.
 
+- `--worldpop-year` _worldpop-year_
+  - Year to use to retrieve WorldPop data for international cities.
+
+    Defaults to the current year.
+
 ## Import
 
 Import files from the `prepare` command into the database.
@@ -685,6 +690,11 @@ bna run "united states" "santa rosa" "new mexico" 3570670
 
     Defaults to all the parts (features, stress, connectivity, measure).
 
+- `--worldpop-year` _worldpop-year_
+  - Year to use to retrieve WorldPop data for international cities.
+
+    Defaults to the current year.
+
 ## Run-with
 
 Provide alternative ways to run the analysis.
@@ -796,6 +806,11 @@ environment.
     option can be repeated if multiple parts are needed.
 
     Defaults to all the parts (features, stress, connectivity, measure).
+
+- `--worldpop-year` _worldpop-year_
+  - Year to use to retrieve WorldPop data for international cities.
+
+    Defaults to the current year.
 
 ## Cache
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "obstore>=0.11.0",
   "osmnx>=2.1.0,<3",
   "platformdirs>=4.10.1",
+  "pycountry>=26.2.16",
   "pygris>=0.2.1",
   "pyrosm>=0.11.0",
   "python-dotenv>=1.2.2,<2",

--- a/utils/bna-batch.py
+++ b/utils/bna-batch.py
@@ -84,6 +84,7 @@ def main(
     export_dir: common.ExportDirOpt = common.DEFAULT_EXPORT_DIR,
     lodes_year: common.LODESYear = None,
     parts: common.ComputeParts = None,
+    worldpop_year: common.WorldPopYear = common.DEFAULT_WORLDPOP_YEAR,
 ) -> None:
     """Process a batch of cities."""
     # Disable logging.
@@ -118,6 +119,7 @@ def main(
                 lodes_year=lodes_year,
                 region=region,
                 with_parts=parts,
+                worldpop_year=worldpop_year,
             )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -333,6 +333,7 @@ dependencies = [
     { name = "obstore" },
     { name = "osmnx" },
     { name = "platformdirs" },
+    { name = "pycountry" },
     { name = "pygris" },
     { name = "pyrosm" },
     { name = "python-dotenv" },
@@ -393,6 +394,7 @@ requires-dist = [
     { name = "obstore", specifier = ">=0.11.0" },
     { name = "osmnx", specifier = ">=2.1.0,<3" },
     { name = "platformdirs", specifier = ">=4.10.1" },
+    { name = "pycountry", specifier = ">=26.2.16" },
     { name = "pygris", specifier = ">=0.2.1" },
     { name = "pyrosm", specifier = ">=0.11.0" },
     { name = "python-dotenv", specifier = ">=1.2.2,<2" },
@@ -1811,6 +1813,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "pycountry"
+version = "26.2.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/061b9e7a48b85cfd69f33c33d2ef784a531c359399ad764243399673c8f5/pycountry-26.2.16.tar.gz", hash = "sha256:5b6027d453fcd6060112b951dd010f01f168b51b4bf8a1f1fc8c95c8d94a0801", size = 7711342, upload-time = "2026-02-17T03:42:52.367Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/42/7703bd45b62fecd44cd7d3495423097e2f7d28bc2e99e7c1af68892ab157/pycountry-26.2.16-py3-none-any.whl", hash = "sha256:115c4baf7cceaa30f59a4694d79483c9167dbce7a9de4d3d571c5f3ea77c305a", size = 8044600, upload-time = "2026-02-17T03:42:49.777Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Pull-Request

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      change)
- [ ] Code cleanup / Refactoring
- [ ] Documentation
- [ ] Infrastructure and automation

## Description

Adds support for using [WorldPop (1km resolution population counts)](https://hub.worldpop.org/geodata/listing?id=136) as a population data source for all international cities. It sets World Pop's default year to the current year, but this can be overridden with the `--worldpop-year` CLI option. WorldPop uses [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1) for country codes, so this feature looks up these codes using [`pycountry`](https://github.com/pycountry/pycountry). If a city is not found by [`pycountry`](https://github.com/pycountry/pycountry), the population dataset falls back to using the _synthetic population_ method.

We also add the ability to handle the `InsufficientResponseError` exception for cases when `osmnx` returns empty data, zero elements, or fewer results than requested; typically when using a structured query over a simple query. This makes running analyses for international cities safer.

See #1061 and #1078 for more context.

<!--
Motivation and Context
Why is this change required? What problem does it solve?
-->

### Reviewing

To review the new feature you can run two cases for an international city (I chose Kingsdown, England because it's small and it tested the change from _Great Britain_ to _United Kingdowm_ recently made by Geofabrik), one with the default year, which should evaluate to 2026, and another one with a specific World Pop year:

1. Checkout this branch
2. Build a Docker image from this branch for testing, `docker build --target main -t brokenspoke-analyzer:main .`
3. To start with a clean setup, `docker compose down`
4. Prepare your containers, `docker compose up -d`
5. Prepare the database, `docker run   --rm   --network brokenspoke-analyzer_default   -e DATABASE_URL   brokenspoke-analyzer:main   -vv configure custom 4 4096 postgres`
6. Reset the database in case you had the results of any previous runs stored in it, `docker run   --rm   --network brokenspoke-analyzer_default   -e DATABASE_URL   brokenspoke-analyzer:main   -vv configure reset`
7. Run the analysis with the default year (ensure that it evaluates to 2026), `docker run   --rm   --network brokenspoke-analyzer_default   -e DATABASE_URL   brokenspoke-analyzer:main   -vv run --no-cache england kingsdown`
8. Export the results, `docker run   --rm   --network brokenspoke-analyzer_default   -u $(id -u):$(id -g)   -v ./results:/usr/src/app/results   -e DATABASE_URL   brokenspoke-analyzer:main   -vv export local england kingsdown`

To test using a specific WorldPop year, repeat the steps above but replace step 7 with

7. Run the analysis with the default year (ensure that it evaluates to 2026), `docker run   --rm   --network brokenspoke-analyzer_default   -e DATABASE_URL   brokenspoke-analyzer:main   -vv run --no-cache england kingsdown --worldpop-year=2025`


## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

- [x] I have updated the documentation accordingly
- [ ] I have updated the Changelog (if applicable)

<!--
Place the URL of the issue here if this PR fixes an existing issue.
Use either the `username/repository#` syntax (preferred) or the *FULL* URL.
-->

Fixes: #1140
