### PR TITLE
Handle Pyrosm Unsupported OSM Regions

### DIFF
--- a/brokenspoke_analyzer/core/datasource.py
+++ b/brokenspoke_analyzer/core/datasource.py
@@ -2,7 +2,6 @@
 
 import pathlib
 import string
-import typing
 from abc import (
     ABC,
     abstractmethod,
@@ -343,22 +342,113 @@ class OSMAdapter(SourceAdapter):
         ds = self.get_dataset()
         return [yarl.URL(ds["url"]), yarl.URL(ds["url"] + ".md5")]
 
-    def get_dataset(self) -> typing.Any:
+    def map_region_name(self, region: str) -> str:
+        """
+        Map the region to the Geofabrik dataset name.
+
+        If no custom mapping is found, return the original region name.
+
+        Exception list:
+        ---------------
+        - As per https://github.com/PeopleForBikes/brokenspoke-analyzer/issues/863
+        we must define an exception for the countries of Malaysia, Singapore and
+        Brunei as they have been grouped together in the Geofabrik dataset.
+        """
+        custom_region_mapping: dict[str, str] = {
+            "brunei": "malaysia_singapore_brunei",
+            "malaysia": "malaysia_singapore_brunei",
+            "singapore": "malaysia_singapore_brunei",
+        }
+        return custom_region_mapping.get(region, region)
+
+    def map_region_url(self, region: str) -> yarl.URL | None:
+        """
+        Map the region to the Geofabrik dataset URL.
+
+        If no custom URL mapping is found, return None.
+
+        Exception list:
+        ---------------
+        - Spanish regions are not yet supported upstream due to a bug in `pyrosm`
+            (https://github.com/pyrosm/pyrosm/pull/381).
+        - Australian regions are not yet supported upstream.
+        - Georgia points to the US state on purpose.
+        - Removing `pyrosm` ambiguities between cities and regions for multiple cities:
+            - Berlin (DE)
+            - Bremen (DE)
+            - Bristol (UK)
+            - Groningen (NL)
+            - Hamburg (DE)
+            - Utrecht (NL)
+        """
+        u = yarl.URL("https://download.geofabrik.de")
+        custom_url_mapping: dict[str, yarl.URL] = {
+            "act": u / "australia-oceania/australia/act-latest.osm.pbf",
+            "andalucia": u / "europe/spain/andalucía-latest.osm.pbf",
+            "aragon": u / "europe/spain/aragón-latest.osm.pbf",
+            "ashmore_cartier": u
+            / "australia-oceania/australia/ashmore-cartier-latest.osm.pbf",
+            "asturias": u / "europe/spain/asturias-latest.osm.pbf",
+            "berlin": u / "europe/germany/berlin-latest.osm.pbf",
+            "bremen": u / "europe/germany/bremen-latest.osm.pbf",
+            "bristol": u / "europe/united-kingdom/england/bristol-latest.osm.pbf",
+            "cantabria": u / "europe/spain/cantabria-latest.osm.pbf",
+            "castilla_y_leon": u / "europe/spain/castilla-y-leon-latest.osm.pbf",
+            "castilla_la_mancha": u / "europe/spain/castilla-la-mancha-latest.osm.pbf",
+            "cataluna": u / "europe/spain/cataluña-latest.osm.pbf",
+            "ceuta": u / "europe/spain/ceuta-latest.osm.pbf",
+            "christmas_island": u
+            / "australia-oceania/australia/christmas-island-latest.osm.pbf",
+            "cocos_islands": u
+            / "australia-oceania/australia/cocos-keeling-latest.osm.pbf",
+            "coral_sea_islands": u
+            / "australia-oceania/australia/coral-sea-islands-latest.osm.pbf",
+            "extremadura": u / "europe/spain/extremadura-latest.osm.pbf",
+            "galicia": u / "europe/spain/galicia-latest.osm.pbf",
+            "georgia": u / "north-america/us/georgia-latest.osm.pbf",
+            "groningen": u / "europe/netherlands/groningen-latest.osm.pbf",
+            "hamburg": u / "europe/germany/hamburg-latest.osm.pbf",
+            "heard_mcdonald": u
+            / "australia-oceania/australia/heard-mcdonald-latest.osm.pbf",
+            "islas_baleares": u / "europe/spain/islas-baleares-latest.osm.pbf",
+            "la_rioja": u / "europe/spain/la rioja-latest.osm.pbf",
+            "madrid": u / "europe/spain/madrid-latest.osm.pbf",
+            "melilla": u / "europe/spain/melilla-latest.osm.pbf",
+            "murcia": u / "europe/spain/murcia-latest.osm.pbf",
+            "navarra": u / "europe/spain/navarra-latest.osm.pbf",
+            "new_south_wales": u
+            / "australia-oceania/australia/new-south-wales-latest.osm.pbf",
+            "norfolk_island": u
+            / "australia-oceania/australia/norfolk-island-latest.osm.pbf",
+            "northern_territory": u
+            / "australia-oceania/australia/northern-territory-latest.osm.pbf",
+            "pais_vasco": u / "europe/spain/pais-vasco-latest.osm.pbf",
+            "queensland": u / "australia-oceania/australia/queensland-latest.osm.pbf",
+            "south_australia": u
+            / "australia-oceania/australia/south-australia-latest.osm.pbf",
+            "tasmania": u / "australia-oceania/australia/tasmania-latest.osm.pbf",
+            "utrecht": u / "europe/netherlands/utrecht-latest.osm.pbf",
+            "valencia": u / "europe/spain/valencia-latest.osm.pbf",
+            "victoria": u / "australia-oceania/australia/victoria-latest.osm.pbf",
+            "western_australia": u
+            / "australia-oceania/australia/western-australia-latest.osm.pbf",
+        }
+        return custom_url_mapping.get(region)
+
+    def get_dataset(self) -> dict[str, str]:
         """Retrieve the OSM dataset metadata."""
-        # Define the region.
-        region = self.region
+        # Normalize the region name.
+        region = utils.normalize_unicode_name(self.region, separator="_")
 
-        # As per https://github.com/PeopleForBikes/brokenspoke-analyzer/issues/863
-        # we must define an exception for the countries of Malaysia, Singapore and
-        # Brunei as they have been grouped together in the Geofabrik dataset.
-        if region in {"malaysia", "singapore", "brunei"}:
-            region = "malaysia_singapore_brunei"
+        # Lookup for a custom URL mapping for the region.
+        if custom_url := self.map_region_url(region):
+            return {"name": custom_url.name, "url": str(custom_url)}
 
-        # Normalize and fetch the dataset metadata.
-        dataset = utils.normalize_unicode_name(region)
-        # search_source() does not accept spaces in the dataset.
-        dataset = dataset.replace(" ", "_")
-        return data.search_source(dataset)
+        # lookup for a custom region mapping for the region.
+        region = self.map_region_name(region)
+
+        # Retrieve the dataset metadata from pyrosm.
+        return data.search_source(region)
 
     def validate(self, datastore: pathlib.Path) -> None:
         """Validate downloaded data."""

--- a/brokenspoke_analyzer/core/utils.py
+++ b/brokenspoke_analyzer/core/utils.py
@@ -99,7 +99,7 @@ def prepare_census_blocks(tabblk_file: pathlib.Path, output_dir: pathlib.Path) -
         file.rename(output_dir / f"population{file.suffix}")
 
 
-def normalize_unicode_name(value: str) -> str:
+def normalize_unicode_name(value: str, separator: str = " ") -> str:
     """
     Normalize unicode names.
 
@@ -110,7 +110,7 @@ def normalize_unicode_name(value: str) -> str:
         >>> normalize_unicode_name("Cañon City")
         canon city
     """
-    return slugify(value, save_order=True, separator=" ")
+    return slugify(value, save_order=True, separator=separator)
 
 
 def prepare_environment(


### PR DESCRIPTION
Implements a mechanism to support OSM regions that are not yet
implemented in `pyrosm`, or that cause problems.

Fixes PeopleForBikes/brokenspoke-analyzer#1197

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
